### PR TITLE
Add FlywayDB migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ hs_err_pid*
 build
 
 .env
+
+# test files
+startServer.sh
+stopServer.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ buildscript {
 plugins {
     id("com.github.ben-manes.versions") version "0.41.0" apply false
     id("com.github.johnrengelman.shadow") version "7.1.2" apply false
+    id("org.jlleitschuh.gradle.ktlint") version "10.3.0" apply false
     kotlin("jvm") version Dependencies.Kotlin.VERSION apply false
     kotlin("plugin.serialization") version Dependencies.Kotlin.VERSION apply false
 }
@@ -26,10 +27,6 @@ allprojects {
 subprojects {
     repositories {
         mavenLocal()
-        maven {
-            name = "jitpack.io"
-            url = uri("https://jitpack.io")
-        }
         mavenCentral()
     }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -78,6 +78,18 @@ object Dependencies {
         const val ALL = "org.postgresql:postgresql:$VERSION"
     }
 
+    object KtorFlyway {
+        private const val VERSION = "2.0.0"
+
+        const val ALL = "io.newm:ktor-flyway-feature:$VERSION"
+    }
+
+    object FlywayDB {
+        private const val VERSION = "9.1.3"
+
+        const val ALL = "org.flywaydb:flyway-core:$VERSION"
+    }
+
     // https://github.com/patrickfav/bcrypt
     object JBCrypt {
         private const val VERSION = "0.9.0"
@@ -100,7 +112,7 @@ object Dependencies {
     }
 
     object Aws {
-        private const val VERSION = "1.12.279"
+        private const val VERSION = "1.12.280"
 
         const val BOM = "com.amazonaws:aws-java-sdk-bom:$VERSION"
         const val S3 = "com.amazonaws:aws-java-sdk-s3"

--- a/newm-server/build.gradle.kts
+++ b/newm-server/build.gradle.kts
@@ -2,12 +2,17 @@ plugins {
     application
     id("com.github.ben-manes.versions")
     id("com.github.johnrengelman.shadow")
+    id("org.jlleitschuh.gradle.ktlint")
     kotlin("jvm")
     kotlin("plugin.serialization")
 }
 
 java.sourceCompatibility = JavaVersion.VERSION_17
 java.targetCompatibility = JavaVersion.VERSION_17
+
+ktlint {
+    version.set("0.42.1")
+}
 
 application {
     mainClass.set("io.newm.server.ApplicationKt")
@@ -50,6 +55,8 @@ dependencies {
 
     implementation(Dependencies.HikariCP.ALL)
     implementation(Dependencies.PostgreSQL.ALL)
+    implementation(Dependencies.KtorFlyway.ALL)
+    implementation(Dependencies.FlywayDB.ALL)
     implementation(Dependencies.Sentry.CORE)
     implementation(Dependencies.Sentry.LOGBACK)
     implementation(Dependencies.ApacheCommonsEmail.ALL)

--- a/newm-server/src/main/kotlin/io/newm/server/Application.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/Application.kt
@@ -1,7 +1,7 @@
 package io.newm.server
 
-import io.ktor.server.application.Application
-import io.ktor.server.routing.routing
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
 import io.newm.server.auth.createAuthenticationRoutes
 import io.newm.server.auth.installAuthentication
 import io.newm.server.content.installContentNegotiation

--- a/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/database/TwoFactorAuthEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/database/TwoFactorAuthEntity.kt
@@ -7,13 +7,13 @@ import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.lowerCase
 import java.time.LocalDateTime
 
-class TwoFactorAuthEntity(id: EntityID<Int>) : Entity<Int>(id) {
+class TwoFactorAuthEntity(id: EntityID<Long>) : Entity<Long>(id) {
 
     var email by TwoFactorAuthTable.email
     var codeHash by TwoFactorAuthTable.codeHash
     var expiresAt by TwoFactorAuthTable.expiresAt
 
-    companion object : EntityClass<Int, TwoFactorAuthEntity>(TwoFactorAuthTable) {
+    companion object : EntityClass<Long, TwoFactorAuthEntity>(TwoFactorAuthTable) {
 
         fun getByEmail(email: String): TwoFactorAuthEntity? = find {
             TwoFactorAuthTable.email.lowerCase() eq email.lowercase()

--- a/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/database/TwoFactorAuthTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/database/TwoFactorAuthTable.kt
@@ -1,9 +1,9 @@
 package io.newm.server.auth.twofactor.database
 
-import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.sql.javatime.datetime
 
-object TwoFactorAuthTable : IntIdTable(name = "two_factor_auth") {
+object TwoFactorAuthTable : LongIdTable(name = "two_factor_auth") {
     val email = text("email")
     val codeHash = text("code_hash")
     val expiresAt = datetime("expires_at")

--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V1__InitialCreation.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V1__InitialCreation.kt
@@ -1,0 +1,88 @@
+package io.newm.server.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("unused")
+class V1__InitialCreation : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            execInBatch(
+                listOf(
+                    """
+                        CREATE TABLE IF NOT EXISTS users
+                        (
+                            id uuid PRIMARY KEY,
+                            oauth_type integer,
+                            oauth_id text,
+                            first_name text,
+                            last_name text,
+                            nickname text,
+                            picture_url text,
+                            role text,
+                            genre text,
+                            email text NOT NULL,
+                            password_hash text
+                        )
+                    """.trimIndent(),
+                    """
+                        CREATE TABLE IF NOT EXISTS two_factor_auth
+                        (
+                            id bigserial PRIMARY KEY,
+                            email text NOT NULL,
+                            code_hash text NOT NULL,
+                            expires_at timestamp without time zone NOT NULL
+                        )
+                    """.trimIndent(),
+                    """
+                        CREATE TABLE IF NOT EXISTS jwts
+                        (
+                            id uuid PRIMARY KEY,
+                            user_id uuid NOT NULL,
+                            expires_at timestamp without time zone NOT NULL,
+                            CONSTRAINT fk_jwts_user_id__id FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE RESTRICT ON DELETE CASCADE
+                        )
+                    """.trimIndent(),
+                    """
+                        CREATE TABLE IF NOT EXISTS songs
+                        (
+                            id uuid PRIMARY KEY,
+                            created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                            owner_id uuid NOT NULL,
+                            title text NOT NULL,
+                            genre text,
+                            cover_art_url text,
+                            description text,
+                            credits text,
+                            audio_url text,
+                            nft_policy_id text,
+                            nft_name text,
+                            CONSTRAINT fk_songs_owner_id__id FOREIGN KEY (owner_id) REFERENCES users (id) ON UPDATE RESTRICT ON DELETE CASCADE
+                        )
+                    """.trimIndent(),
+                    """
+                        CREATE TABLE IF NOT EXISTS playlists
+                        (
+                            id uuid PRIMARY KEY,
+                            created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                            owner_id uuid NOT NULL,
+                            name text NOT NULL,
+                            CONSTRAINT fk_playlists_owner_id__id FOREIGN KEY (owner_id) REFERENCES users (id) ON UPDATE RESTRICT ON DELETE CASCADE
+                        )
+                    """.trimIndent(),
+                    """
+                        CREATE TABLE IF NOT EXISTS songs_in_playlists
+                        (
+                            song_id uuid NOT NULL,
+                            playlist_id uuid NOT NULL,
+                            CONSTRAINT pk_songs_in_playlists PRIMARY KEY (song_id, playlist_id),
+                            CONSTRAINT fk_songs_in_playlists_playlist_id__id FOREIGN KEY (playlist_id) REFERENCES playlists (id) ON UPDATE RESTRICT ON DELETE CASCADE,
+                            CONSTRAINT fk_songs_in_playlists_song_id__id FOREIGN KEY (song_id) REFERENCES songs (id) ON UPDATE RESTRICT ON DELETE CASCADE
+                        )
+                    """.trimIndent()
+                )
+            )
+        }
+    }
+}

--- a/newm-server/src/main/resources/application.conf
+++ b/newm-server/src/main/resources/application.conf
@@ -66,7 +66,6 @@ database {
     jdbcUrl = ${DATABASE_JDBC_URL}
     username = ${DATABASE_USERNAME}
     password = ${DATABASE_PASSWORD}
-    maximumPoolSize = 10
 }
 
 cors {


### PR DESCRIPTION
Flyway is not as easy to use as SchemaUtils.create..., but it does allow us to update our database over time adding columns, tables, and additional indexes as needed. 

The system scans the migrations folder for classes matching the pattern and plays back the migrations in order.  The results of migrations are stored in a `flyway_schema_history` table so they are only applied to the database once. Hashes of migrations are also stored in this table so once a migration is applied to the db, it cannot be changed and re-run.  Instead, you should create another migration file to fix what you broke.