### PR TITLE
newm-chain: store utxo datum values

### DIFF
--- a/newm-chain-db/src/main/kotlin/io/newm/chain/database/migration/V3__AlterLedgerUtxos.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/database/migration/V3__AlterLedgerUtxos.kt
@@ -1,0 +1,23 @@
+package io.newm.chain.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("unused")
+class V3__AlterLedgerUtxos : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            execInBatch(
+                listOf(
+                    """
+                        ALTER TABLE "ledger_utxos" ADD COLUMN "datum_hash" TEXT
+                    """.trimIndent(),
+                    """
+                        ALTER TABLE "ledger_utxos" ADD COLUMN "datum" TEXT
+                    """.trimIndent(),
+                )
+            )
+        }
+    }
+}

--- a/newm-chain-db/src/main/kotlin/io/newm/chain/database/repository/LedgerRepositoryImpl.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/database/repository/LedgerRepositoryImpl.kt
@@ -66,6 +66,8 @@ class LedgerRepositoryImpl : LedgerRepository {
                     hash = row[LedgerUtxosTable.txId],
                     ix = row[LedgerUtxosTable.txIx].toLong(),
                     lovelace = BigInteger(row[LedgerUtxosTable.lovelace]),
+                    datumHash = row[LedgerUtxosTable.datumHash],
+                    datum = row[LedgerUtxosTable.datum],
                     nativeAssets = nativeAssets
                 )
             }
@@ -180,6 +182,8 @@ class LedgerRepositoryImpl : LedgerRepository {
                 row[ledgerId] = ledgerTableId
                 row[txId] = createdUtxo.hash
                 row[txIx] = createdUtxo.ix.toInt()
+                row[datumHash] = createdUtxo.datumHash
+                row[datum] = createdUtxo.datum
                 row[lovelace] = createdUtxo.lovelace.toString()
                 row[blockCreated] = blockNumber
                 row[slotCreated] = slotNumber

--- a/newm-chain-db/src/main/kotlin/io/newm/chain/database/table/LedgerUtxosTable.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/database/table/LedgerUtxosTable.kt
@@ -13,6 +13,12 @@ object LedgerUtxosTable : LongIdTable(name = "ledger_utxos") {
     // transaction index
     val txIx: Column<Int> = integer("tx_ix")
 
+    // datum hash
+    val datumHash: Column<String?> = text("datum_hash").nullable()
+
+    // inline datum value
+    val datum: Column<String?> = text("datum").nullable()
+
     // lovelaces in this utxo
     val lovelace: Column<String> = text("lovelace")
 

--- a/newm-chain-db/src/main/kotlin/io/newm/chain/model/CreatedUtxo.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/model/CreatedUtxo.kt
@@ -12,6 +12,8 @@ data class CreatedUtxo(
     val hash: String,
     val ix: Long,
     @Contextual val lovelace: BigInteger,
+    val datumHash: String?,
+    val datum: String?,
     val nativeAssets: List<NativeAsset>,
     val cbor: ByteArray?,
 ) {
@@ -25,7 +27,13 @@ data class CreatedUtxo(
         if (hash != other.hash) return false
         if (ix != other.ix) return false
         if (lovelace != other.lovelace) return false
+        if (datumHash != other.datumHash) return false
+        if (datum != other.datum) return false
         if (nativeAssets != other.nativeAssets) return false
+        if (cbor != null) {
+            if (other.cbor == null) return false
+            if (!cbor.contentEquals(other.cbor)) return false
+        } else if (other.cbor != null) return false
 
         return true
     }
@@ -37,7 +45,10 @@ data class CreatedUtxo(
         result = 31 * result + hash.hashCode()
         result = 31 * result + ix.hashCode()
         result = 31 * result + lovelace.hashCode()
+        result = 31 * result + (datumHash?.hashCode() ?: 0)
+        result = 31 * result + (datum?.hashCode() ?: 0)
         result = 31 * result + nativeAssets.hashCode()
+        result = 31 * result + (cbor?.contentHashCode() ?: 0)
         return result
     }
 }

--- a/newm-chain-db/src/main/kotlin/io/newm/chain/util/CardanoKtx.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/util/CardanoKtx.kt
@@ -261,6 +261,8 @@ private fun List<UtxoOutput>.toCreatedUtxoList(txId: String) = this.mapIndexed {
         hash = txId,
         ix = index.toLong(),
         lovelace = utxoOutput.value.coins,
+        datumHash = utxoOutput.datumHash,
+        datum = utxoOutput.datum,
         nativeAssets = utxoOutput.value.assets?.map { entry ->
             NativeAsset(
                 policy = entry.key.substringBefore('.'),

--- a/newm-server/src/main/kotlin/io/newm/server/content/ContentNegotiationInstall.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/content/ContentNegotiationInstall.kt
@@ -4,8 +4,10 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 
+@OptIn(ExperimentalSerializationApi::class)
 fun Application.installContentNegotiation() {
     install(ContentNegotiation) {
         json(

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/SongEncodeMessageReceiver.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/SongEncodeMessageReceiver.kt
@@ -11,6 +11,7 @@ import io.newm.server.features.song.model.Song
 import io.newm.server.features.song.model.SongEncodeMessage
 import io.newm.server.features.song.repo.SongRepository
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.slf4j.MarkerFactory
@@ -21,6 +22,7 @@ class SongEncodeMessageReceiver : SqsMessageReceiver {
     private val logger: Logger by inject()
     private val marker = MarkerFactory.getMarker(SongEncodeMessageReceiver::class.java.simpleName)
 
+    @OptIn(ExperimentalSerializationApi::class)
     val json = Json {
         ignoreUnknownKeys = true
         explicitNulls = false


### PR DESCRIPTION
Datum values on UTxOs are used by the minting process. We will need to be able to query these values so that we can safely mint the next NFT in our sequence. We could keep track of this ourselves, but it's better to rely on the on-chain data.