### PR TITLE
fix: update to use getSecureString for more config variables

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/repo/TwoFactorAuthRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/repo/TwoFactorAuthRepositoryImpl.kt
@@ -3,6 +3,7 @@ package io.newm.server.auth.twofactor.repo
 import io.ktor.server.application.ApplicationEnvironment
 import io.ktor.util.logging.Logger
 import io.newm.server.auth.twofactor.database.TwoFactorAuthEntity
+import io.newm.server.ktx.getSecureString
 import io.newm.shared.koin.inject
 import io.newm.shared.ktx.debug
 import io.newm.shared.ktx.getBoolean
@@ -39,16 +40,16 @@ internal class TwoFactorAuthRepositoryImpl(
             .replaceFirst("{{code}}", code)
 
         HtmlEmail().apply {
-            hostName = config.getString("smtpHost")
-            setSmtpPort(config.getInt("smtpPort"))
+            hostName = config.getSecureString("smtpHost")
+            setSmtpPort(config.getSecureString("smtpPort").toInt())
             isSSLOnConnect = config.getBoolean("sslOnConnect")
             setAuthenticator(
                 DefaultAuthenticator(
-                    config.getString("userName"),
-                    config.getString("password")
+                    config.getSecureString("userName"),
+                    config.getSecureString("password")
                 )
             )
-            setFrom(config.getString("from"))
+            setFrom(config.getSecureString("from"))
             addTo(email)
             subject = config.getString("subject")
             setHtmlMsg(message)

--- a/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/repo/TwoFactorAuthRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/auth/twofactor/repo/TwoFactorAuthRepositoryImpl.kt
@@ -41,7 +41,7 @@ internal class TwoFactorAuthRepositoryImpl(
 
         HtmlEmail().apply {
             hostName = config.getSecureString("smtpHost")
-            setSmtpPort(config.getSecureString("smtpPort").toInt())
+            setSmtpPort(config.getInt("smtpPort"))
             isSSLOnConnect = config.getBoolean("sslOnConnect")
             setAuthenticator(
                 DefaultAuthenticator(

--- a/newm-server/src/main/kotlin/io/newm/server/features/cardano/CardanoKoinModule.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/cardano/CardanoKoinModule.kt
@@ -7,9 +7,11 @@ import io.ktor.server.application.ApplicationEnvironment
 import io.newm.chain.grpc.NewmChainGrpcKt.NewmChainCoroutineStub
 import io.newm.server.features.cardano.repo.CardanoRepository
 import io.newm.server.features.cardano.repo.CardanoRepositoryImpl
+import io.newm.server.ktx.getSecureConfigString
 import io.newm.shared.ktx.getConfigBoolean
 import io.newm.shared.ktx.getConfigInt
 import io.newm.shared.ktx.getConfigString
+import kotlinx.coroutines.runBlocking
 import org.koin.dsl.module
 
 val cardanoKoinModule = module {
@@ -17,7 +19,7 @@ val cardanoKoinModule = module {
         CardanoRepositoryImpl(
             get(),
             get(),
-            get<ApplicationEnvironment>().getConfigString("aws.kms.keyId"),
+            runBlocking { get<ApplicationEnvironment>().getSecureConfigString("aws.kms.keyId") },
             get(),
         )
     }
@@ -25,7 +27,7 @@ val cardanoKoinModule = module {
         val environment = get<ApplicationEnvironment>()
         val host = environment.getConfigString("newmChain.host")
         val port = environment.getConfigInt("newmChain.port")
-        val jwt = environment.getConfigString("newmChain.jwt")
+        val jwt = runBlocking { environment.getSecureConfigString("newmChain.jwt") }
         val secure = environment.getConfigBoolean("newmChain.secure")
         val channel = ManagedChannelBuilder.forAddress(host, port).apply {
             if (secure) {

--- a/newm-server/src/main/kotlin/io/newm/server/features/idenfy/repo/IdenfyRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/idenfy/repo/IdenfyRepositoryImpl.kt
@@ -18,6 +18,7 @@ import io.newm.shared.koin.inject
 import io.newm.shared.ktx.debug
 import io.newm.shared.ktx.getBoolean
 import io.newm.shared.ktx.getConfigChild
+import io.newm.shared.ktx.getInt
 import io.newm.shared.ktx.getString
 import io.newm.shared.ktx.propertiesFromResource
 import io.newm.shared.ktx.toUUID
@@ -111,7 +112,7 @@ class IdenfyRepositoryImpl(
 
         HtmlEmail().apply {
             hostName = config.getSecureString("smtpHost")
-            setSmtpPort(config.getSecureString("smtpPort").toInt())
+            setSmtpPort(config.getInt("smtpPort"))
             isSSLOnConnect = config.getBoolean("sslOnConnect")
             setAuthenticator(
                 DefaultAuthenticator(

--- a/newm-server/src/main/kotlin/io/newm/server/features/idenfy/repo/IdenfyRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/idenfy/repo/IdenfyRepositoryImpl.kt
@@ -18,7 +18,6 @@ import io.newm.shared.koin.inject
 import io.newm.shared.ktx.debug
 import io.newm.shared.ktx.getBoolean
 import io.newm.shared.ktx.getConfigChild
-import io.newm.shared.ktx.getInt
 import io.newm.shared.ktx.getString
 import io.newm.shared.ktx.propertiesFromResource
 import io.newm.shared.ktx.toUUID
@@ -111,16 +110,16 @@ class IdenfyRepositoryImpl(
         }
 
         HtmlEmail().apply {
-            hostName = config.getString("smtpHost")
-            setSmtpPort(config.getInt("smtpPort"))
+            hostName = config.getSecureString("smtpHost")
+            setSmtpPort(config.getSecureString("smtpPort").toInt())
             isSSLOnConnect = config.getBoolean("sslOnConnect")
             setAuthenticator(
                 DefaultAuthenticator(
-                    config.getString("userName"),
-                    config.getString("password")
+                    config.getSecureString("userName"),
+                    config.getSecureString("password")
                 )
             )
-            setFrom(config.getString("from"))
+            setFrom(config.getSecureString("from"))
             addTo(email)
             subject = config.getString("subject")
             setHtmlMsg(message)


### PR DESCRIPTION
Several variables in environment are repeated in the secret manager but still referenced in the environment directly. This change updates the code that reads the environment to prefer reading the data from secret manager. These changes are required to adopt the new infrastructure that prefers secretmanager for config values.