### PR TITLE
CU-863gy08ce: Fix fee calculation

### DIFF
--- a/newm-chain-db/src/main/kotlin/io/newm/chain/database/repository/LedgerRepository.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/database/repository/LedgerRepository.kt
@@ -58,4 +58,6 @@ interface LedgerRepository {
     fun queryLedgerAssetMetadataList(assetId: Long, parentId: Long? = null): List<LedgerAssetMetadata>
 
     fun queryTransactionConfirmationCounts(txIds: List<String>): Map<String, Long>
+
+    fun queryPublicKeyHashByOutputRef(hash: String, ix: Int): String?
 }


### PR DESCRIPTION
We're not taking into account the bytes in the transaction that will eventually be filled by the signatures. If using the transactionBuilder to create an unsigned transaction, we need to add some dummy signatures so the eventual bytes calculation is correct.