### PR TITLE
add: new /stream route for generating secure signing data (cookies)

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -184,6 +184,7 @@ object Dependencies {
 
     object Aws {
         private const val VERSION = "1.12.457"
+        private const val VERSION2 = "2.20.84"
         private const val JAXB_VERSION = "2.3.1"
 
         const val BOM = "com.amazonaws:aws-java-sdk-bom:$VERSION"
@@ -192,6 +193,9 @@ object Dependencies {
         const val KMS = "com.amazonaws:aws-java-sdk-kms"
         const val SECRETS_MANAGER = "com.amazonaws:aws-java-sdk-secretsmanager"
         const val JAXB = "javax.xml.bind:jaxb-api:$JAXB_VERSION"
+
+        const val BOM2 = "software.amazon.awssdk:bom:$VERSION2"
+        const val CLOUDFRONT = "software.amazon.awssdk:cloudfront"
     }
 
     object Arweave {

--- a/newm-server/build.gradle.kts
+++ b/newm-server/build.gradle.kts
@@ -95,6 +95,9 @@ dependencies {
     implementation(Dependencies.Aws.SECRETS_MANAGER)
     implementation(Dependencies.Aws.JAXB)
 
+    implementation(platform(Dependencies.Aws.BOM2))
+    implementation(Dependencies.Aws.CLOUDFRONT)
+
     implementation(Dependencies.Arweave.ARWEAVE4S)
     implementation(Dependencies.Arweave.SCALA_JAVA8_COMPAT)
 
@@ -113,6 +116,7 @@ dependencies {
 
 tasks {
     shadowJar {
+        isZip64 = true
         // defaults to project.name
         // archiveBaseName.set("${project.name}-fat")
 

--- a/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
@@ -21,13 +21,7 @@ class CloudfrontAudioStreamData(private val args: CloudfrontAudioStreamArguments
 
     override val url: String
         get() = this.args.url
-    private val _cookies: Map<String, String>
-    override val cookies: Map<String, String>
-        get() = this._cookies
-
-    init {
-        this._cookies = createSignedCookies()
-    }
+    override val cookies: Map<String, String> by lazy { createSignedCookies() }
 
     private fun createSignedCookies(): Map<String, String> {
         val streamUrl = URLBuilder(this.url).build()

--- a/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
@@ -1,0 +1,69 @@
+package io.newm.server.aws.cloudfront
+
+import io.ktor.http.URLBuilder
+import io.ktor.http.fullPath
+import io.newm.server.features.song.model.AudioStreamData
+import io.newm.server.security.PrivateKeyReader
+import software.amazon.awssdk.services.cloudfront.CloudFrontUtilities
+import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class CloudfrontAudioStreamArguments(
+    var url: String,
+    var keyPairId: String,
+    var privateKey: String,
+    var expirationDate: Instant = Instant.now().plus(1, ChronoUnit.DAYS)
+)
+
+class CloudfrontAudioStreamData(private val args: CloudfrontAudioStreamArguments) :
+    AudioStreamData {
+
+    override val url: String
+        get() = this.args.url
+    private val _cookies: Map<String, String>
+    override val cookies: Map<String, String>
+        get() = this._cookies
+
+    init {
+        this._cookies = createSignedCookies()
+    }
+
+    private fun createSignedCookies(): Map<String, String> {
+        val streamUrl = URLBuilder(this.url).build()
+
+        // resource is the "dirname" of the URL with the filename removed,
+        // effectively granting access to the entire "directory"
+        val resourceUrl = "${streamUrl.protocol}://${streamUrl.host}${
+            streamUrl.fullPath.subSequence(
+                0,
+                streamUrl.fullPath.lastIndexOf("/")
+            )
+        }"
+
+        val customRequest = CustomSignerRequest.builder()
+            .resourceUrl(resourceUrl)
+            .privateKey(PrivateKeyReader.readFromString(args.privateKey))
+            .keyPairId(args.keyPairId)
+            .expirationDate(args.expirationDate)
+            // optional
+            //  .activeDate(activeDate)
+            //  .ipRange("192.168.0.1/24")
+            .build()
+
+        val cloudFrontUtilities = CloudFrontUtilities.create()
+        val signedCookies = cloudFrontUtilities.getCookiesForCustomPolicy(customRequest)
+        val (signatureHeaderName, signatureHeaderValue) = signedCookies.signatureHeaderValue().split("=")
+        val (keyPairIdHeaderName, keyPairIdHeaderValue) = signedCookies.keyPairIdHeaderValue().split("=")
+        val (policyHeaderName, policyHeaderValue) = signedCookies.policyHeaderValue().split("=")
+
+        return mapOf(
+            signatureHeaderName to signatureHeaderValue,
+            keyPairIdHeaderName to keyPairIdHeaderValue,
+            policyHeaderName to policyHeaderValue
+        )
+    }
+}
+
+fun cloudfrontAudioStreamData(init: CloudfrontAudioStreamArguments.() -> Unit): CloudfrontAudioStreamData =
+    CloudfrontAudioStreamData(CloudfrontAudioStreamArguments("", "", "").apply(init))

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/SongRoutes.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/SongRoutes.kt
@@ -7,25 +7,26 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.route
 import io.newm.server.auth.jwt.AUTH_JWT
-import io.newm.server.ktx.limit
-import io.newm.server.ktx.myUserId
-import io.newm.server.ktx.offset
-import io.newm.server.ktx.songId
 import io.newm.server.features.model.CountResponse
+import io.newm.server.features.song.model.AudioStreamResponse
+import io.newm.server.features.song.model.AudioUploadRequest
+import io.newm.server.features.song.model.AudioUploadResponse
 import io.newm.server.features.song.model.MintPaymentRequest
 import io.newm.server.features.song.model.MintPaymentResponse
 import io.newm.server.features.song.model.SongIdBody
 import io.newm.server.features.song.model.StreamTokenAgreementRequest
-import io.newm.server.features.song.model.AudioUploadRequest
-import io.newm.server.features.song.model.AudioUploadResponse
 import io.newm.server.features.song.model.songFilters
 import io.newm.server.features.song.repo.SongRepository
+import io.newm.server.ktx.limit
+import io.newm.server.ktx.myUserId
+import io.newm.server.ktx.offset
+import io.newm.server.ktx.songId
+import io.newm.shared.koin.inject
 import io.newm.shared.ktx.delete
 import io.newm.shared.ktx.get
 import io.newm.shared.ktx.patch
 import io.newm.shared.ktx.post
 import io.newm.shared.ktx.put
-import io.newm.shared.koin.inject
 
 private const val SONGS_PATH = "v1/songs"
 
@@ -71,6 +72,15 @@ fun Routing.createSongRoutes() {
                                 songId = songId,
                                 requesterId = myUserId,
                                 fileName = receive<AudioUploadRequest>().fileName
+                            )
+                        )
+                    )
+                }
+                get("stream") {
+                    respond(
+                        AudioStreamResponse(
+                            songRepository.generateAudioStreamData(
+                                songId = songId,
                             )
                         )
                     )

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/model/AudioStreamResponse.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/model/AudioStreamResponse.kt
@@ -1,0 +1,16 @@
+package io.newm.server.features.song.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AudioStreamResponse(
+    val url: String,
+    val cookies: Map<String, String>
+) {
+    constructor(data: AudioStreamData) : this(data.url, data.cookies)
+}
+
+interface AudioStreamData {
+    val url: String
+    val cookies: Map<String, String>
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepository.kt
@@ -2,6 +2,7 @@ package io.newm.server.features.song.repo
 
 import io.newm.chain.grpc.Utxo
 import io.newm.server.aws.s3.model.PresignedPost
+import io.newm.server.features.song.model.AudioStreamData
 import io.newm.server.features.song.model.Song
 import io.newm.server.features.song.model.SongFilters
 import java.util.UUID
@@ -16,6 +17,7 @@ interface SongRepository {
     suspend fun getGenres(filters: SongFilters, offset: Int, limit: Int): List<String>
     suspend fun getGenreCount(filters: SongFilters): Long
     suspend fun generateAudioUpload(songId: UUID, requesterId: UUID, fileName: String): PresignedPost
+    suspend fun generateAudioStreamData(songId: UUID): AudioStreamData
     suspend fun processStreamTokenAgreement(songId: UUID, requesterId: UUID, accepted: Boolean)
 
     suspend fun getMintingPaymentAmount(songId: UUID, requesterId: UUID): String

--- a/newm-server/src/main/kotlin/io/newm/server/security/KeyParser.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/security/KeyParser.kt
@@ -1,0 +1,17 @@
+package io.newm.server.security
+
+import io.ktor.util.decodeBase64Bytes
+
+class KeyParser {
+    companion object {
+        fun parse(key: String): ByteArray {
+            // Remove the header and footer lines from the private key string
+            val base64Key = key
+                .replace(Regex("\\-\\-\\-\\-\\-.*"), "")
+                .replace(Regex("\\n"), "")
+                .trim()
+
+            return base64Key.decodeBase64Bytes()
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/security/KeyParser.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/security/KeyParser.kt
@@ -2,16 +2,13 @@ package io.newm.server.security
 
 import io.ktor.util.decodeBase64Bytes
 
-class KeyParser {
-    companion object {
-        fun parse(key: String): ByteArray {
-            // Remove the header and footer lines from the private key string
-            val base64Key = key
-                .replace(Regex("\\-\\-\\-\\-\\-.*"), "")
-                .replace(Regex("\\n"), "")
-                .trim()
+object KeyParser {
+    fun parse(key: String): ByteArray {
+        // Remove the header and footer lines from the private key string
+        val base64Key = key
+            .replace("\\-\\-\\-\\-\\-.*".toRegex(), "")
+            .replace("\\s".toRegex(), "")
 
-            return base64Key.decodeBase64Bytes()
-        }
+        return base64Key.decodeBase64Bytes()
     }
 }

--- a/newm-server/src/main/kotlin/io/newm/server/security/PrivateKeyReader.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/security/PrivateKeyReader.kt
@@ -1,0 +1,15 @@
+package io.newm.server.security
+
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+
+class PrivateKeyReader {
+    companion object {
+        fun readFromString(privateKey: String): PrivateKey {
+            val keyBytes = KeyParser.parse(privateKey)
+            val keySpec = PKCS8EncodedKeySpec(keyBytes)
+            return KeyFactory.getInstance("RSA").generatePrivate(keySpec)
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/security/PrivateKeyReader.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/security/PrivateKeyReader.kt
@@ -4,12 +4,10 @@ import java.security.KeyFactory
 import java.security.PrivateKey
 import java.security.spec.PKCS8EncodedKeySpec
 
-class PrivateKeyReader {
-    companion object {
-        fun readFromString(privateKey: String): PrivateKey {
-            val keyBytes = KeyParser.parse(privateKey)
-            val keySpec = PKCS8EncodedKeySpec(keyBytes)
-            return KeyFactory.getInstance("RSA").generatePrivate(keySpec)
-        }
+object PrivateKeyReader {
+    fun readFromString(privateKey: String): PrivateKey {
+        val keyBytes = KeyParser.parse(privateKey)
+        val keySpec = PKCS8EncodedKeySpec(keyBytes)
+        return KeyFactory.getInstance("RSA").generatePrivate(keySpec)
     }
 }

--- a/newm-server/src/main/resources/application.conf
+++ b/newm-server/src/main/resources/application.conf
@@ -128,6 +128,8 @@ aws {
     cloudFront {
         audioStream {
             hostUrl = ${AWS_AUDIO_CLOUDFRONT_HOST_URL}
+            keyPairId = ${AWS_AUDIO_CLOUDFRONT_SIGNING_KEYPAIR_ID}
+            privateKey = ${AWS_AUDIO_CLOUDFRONT_SIGNING_PRIVATE_KEY}
         }
     }
     kms {

--- a/newm-server/src/main/resources/application.conf
+++ b/newm-server/src/main/resources/application.conf
@@ -128,8 +128,8 @@ aws {
     cloudFront {
         audioStream {
             hostUrl = ${AWS_AUDIO_CLOUDFRONT_HOST_URL}
-            keyPairId = ${AWS_AUDIO_CLOUDFRONT_SIGNING_KEYPAIR_ID}
-            privateKey = ${AWS_AUDIO_CLOUDFRONT_SIGNING_PRIVATE_KEY}
+            keyPairId = ${AWS_SECRET_ARN}
+            privateKey = ${AWS_SECRET_ARN}
         }
     }
     kms {

--- a/newm-server/src/test/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamDataTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamDataTest.kt
@@ -1,0 +1,31 @@
+package io.newm.server.aws.cloudfront
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.server.application.ApplicationEnvironment
+import io.newm.server.BaseApplicationTests
+import io.newm.server.ktx.getSecureConfigString
+import io.newm.shared.koin.inject
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+class CloudfrontAudioStreamDataTest : BaseApplicationTests() {
+    @Test
+    fun testPolicyResourcePathUpdated() = runBlocking {
+        val environment: ApplicationEnvironment by inject()
+        val pk = environment.getSecureConfigString("aws.cloudFront.audioStream.privateKey")
+
+        val keyPairId = "TEST_KEYPAIR_ID"
+        val streamData = cloudfrontAudioStreamData {
+            this.url = "https://newm.io/path/filename.m3u8"
+            this.keyPairId = keyPairId
+            this.privateKey = pk
+        }
+
+        assertThat(streamData.cookies).containsKey("CloudFront-Key-Pair-Id")
+        assertThat(streamData.cookies["CloudFront-Key-Pair-Id"]).isEqualTo(keyPairId)
+        assertThat(streamData.cookies).containsKey("CloudFront-Policy")
+        val policy = streamData.cookies["CloudFront-Policy"]
+        // policy is a slightly customized base64 encoded string, so just checking that it exists for now
+        assertThat(policy).isNotNull()
+    }
+}

--- a/newm-server/src/test/kotlin/io/newm/server/security/KeyParserTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/security/KeyParserTest.kt
@@ -1,0 +1,18 @@
+package io.newm.server.security
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.server.application.ApplicationEnvironment
+import io.newm.server.BaseApplicationTests
+import io.newm.server.ktx.getSecureConfigString
+import io.newm.shared.koin.inject
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+class KeyParserTest : BaseApplicationTests() {
+    @Test
+    fun testRSAPrivateKeyPcks8() = runBlocking {
+        val environment: ApplicationEnvironment by inject()
+        val pk = environment.getSecureConfigString("aws.cloudFront.audioStream.privateKey")
+        assertThat(KeyParser.parse(pk)).isNotEmpty()
+    }
+}

--- a/newm-server/src/test/kotlin/io/newm/server/security/PrivateKeyReaderTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/security/PrivateKeyReaderTest.kt
@@ -1,0 +1,19 @@
+package io.newm.server.security
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.server.application.ApplicationEnvironment
+import io.newm.server.BaseApplicationTests
+import io.newm.server.ktx.getSecureConfigString
+import io.newm.shared.koin.inject
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+class PrivateKeyReaderTest : BaseApplicationTests() {
+
+    @Test
+    fun testParsePrivateKey() = runBlocking {
+        val environment: ApplicationEnvironment by inject()
+        val pk = environment.getSecureConfigString("aws.cloudFront.audioStream.privateKey")
+        assertThat(PrivateKeyReader.readFromString(pk)).isNotNull()
+    }
+}

--- a/newm-server/src/test/resources/test-application.conf
+++ b/newm-server/src/test/resources/test-application.conf
@@ -34,6 +34,42 @@ aws {
             bigSongFile = "src/test/resources/example_large.mp3"
         }
     }
+    cloudFront {
+        audioStream {
+            hostUrl = "https://media.test.newm.io"
+            keyPairId = "12345"
+            privateKey = """
+            -----BEGIN PRIVATE KEY-----
+        MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCnao35J5BqKmjd
+        Xo2o84nPBuIwMqMV1Tl02Myhycj1C+fcKj+XThmVRqQNdF0X0vmhT2du6rHxyCg9
+        f5dhWSBfO+K5/NyscmI/aFrsWYI/Y49Dbrsgqk8DOcJo2Y5DcI/QjY0Sl9C740rp
+        RNDNZZ1nMirWmYmvVbZeeaHz6bmGFu/jcfuEc8uo/OjlKdiSKfgyKhYebAtOKtcY
+        BlGyPukkPCd9FLFwYtjpVxU2oT33bibo6MzLAQDj2wdJksuh/HpZn/7wm0VE9Ymv
+        CDVT5DsTrSRKri4tUl8fULMGPvVwKArhLtNomaa0rMr1F0c7sRz17ll3vs+7avbs
+        OW5Pt2MNAgMBAAECggEACADbCqcuizS90J9djE8gLmp4068IBtorpf9bQPzBg51v
+        FyJZ6eTM6kr3OsFuVd47GtAN9Mp5eUKFUfNQjFHTb1oQi62f6wqI0dkuR5A73sXm
+        qmWXwocBwfi354VG/Mhbx6+Mp+/kBadnBGHKzZbnAHDwhVPPtjcVwcx0xpFM0jEg
+        uWZsCTO/QcgiQ3lG1A0rsI/HztLWsrgfWD0Gfgk3RBRJQVIcvDnVmv+jIoKNhse7
+        RlAdAlevhHZouldpSglHCl/+AvBxWcjlujjU+jrrZYV9B0tVV9He7hMAQpNsukan
+        00YJrjWpWa7lUwuCybIqAUfkvL4uUulwVdBM8W/hDQKBgQDQMs6VhapczUXsCLVh
+        WhFLHEbVM1AYjjysp2jLrL3Sy8jjU+VNXBUqEJiK3R64c4uPYNuQDy7KQnaQiL0M
+        mfsFwRTO/sonGNLK7LAxE6Qbs4DDANLN2QQ30vqJ0Ktgb7XoCuMli+jR0TFIx3ec
+        hFAQHLTxxMzrrJDbMRH/US2p2wKBgQDN2rUYEufKvV4+/00jW2VCo19XlaslCbrY
+        ni4CoB/9ezbF3jntU2tbmNOcZU0+PHLjhNVSGstHiFAvHP5OEgKC7HVB2Ek1hepn
+        kF9vnSoCafzxXMjGnmZHVVSUxnm8kwD1VHfjcbQN5QPNMY8syHXpL669hmtOw8d1
+        Q/e7/ME/NwKBgQCAPpuT7Mb47RTiBKc9dU5rttpG35m51nu3WlOqChjPbOmsZfQ8
+        B7mdtKVR/Ey9D6dqxR3aChAnVHNWKnRQ+9RtQfcAXl/FX3wQtWT+hfuzeImbFLnF
+        RKVdgZ8EHz5BY+5oJbSvXxQlkjdKflvGVJZApn4q4q/bh+ueqQZOAAIhuwKBgDgJ
+        QSK8grx9sBoWBTmKt5XcQyfkZiI+883jwUKVtB+cWtyiEcK44pCcmX4JVW2Lpvqo
+        PimLgaqHQMySZ+d4n5ZkJ8c0yTj4q0Zl1pTbg4QEtgY966mllNH2OIAHRzw+CBTA
+        WaJgYVMm9FH3G7JlHzPK9xZAcRWP1cvmJJnXxAMhAoGAFRjW/8/dJonWv0FYMRrq
+        sI8HZ8YgL6oRhyiQRB22qsyjGJcx65IC2KnqM7Vs/rR6MTIcuG29c0wFPolSuXFT
+        RFDXy+nKvaNfE8kmYJ4HuPc2EMLpaUDdFcGeBrtH6oJt1UZx3zSSNnbQtRZC1qwp
+        ou0SViIVbdPNHigZ374t4oU=
+        -----END PRIVATE KEY-----
+            """
+        }
+    }
 }
 
 idenfy {


### PR DESCRIPTION
This PR creates a new route `/v1/songs/${songId}/stream` that returns the url and meta data the player needs to stream the song.  Currently the meta data consists of the signed cookies needed to access the CloudFront CDN.

I chose the approach of making a separate call to obtain streaming metadata to give us maximum flexibility if we need to adjust the streaming requirements in the future.

This will require the client to perform an additional request before streaming a song, I'll work with @scandycuz  on how to implement that as a follow up task.