### PR TITLE
fix: trying SameSite=Lax to save cookies when streaming

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
@@ -58,7 +58,7 @@ class CloudfrontAudioStreamData(
         value = value,
         path = "/",
         domain = args.cookieDomain,
-        extensions = mapOf("SameSite" to "Strict")
+        extensions = mapOf("SameSite" to "Lax")
     )
 }
 


### PR DESCRIPTION
SameSite=Strict worked when developing locally, but its likely because I disabled certain security checks in my browser