### PR TITLE
Fix Circular dependency in Koin

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/daemon/DaemonsKoinModule.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/daemon/DaemonsKoinModule.kt
@@ -4,8 +4,10 @@ import io.newm.shared.daemon.Daemon
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
+private val quartzSchedulerDaemon by lazy { QuartzSchedulerDaemon() }
+
 val daemonsKoinModule = module {
     single { AwsSqsDaemon() } bind Daemon::class
-    single<QuartzSchedulerDaemon> { QuartzSchedulerDaemon() }
-    single { get<QuartzSchedulerDaemon>() } bind Daemon::class
+    single<QuartzSchedulerDaemon> { quartzSchedulerDaemon }
+    single { quartzSchedulerDaemon } bind Daemon::class
 }


### PR DESCRIPTION
Don't reference something injected inside the same module.