### PR TITLE
RFC: Custom config loader to retrieve AWS secrets

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/Application.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/Application.kt
@@ -23,7 +23,9 @@ import io.newm.server.staticcontent.createStaticContentRoutes
 import io.newm.server.statuspages.installStatusPages
 import io.newm.shared.daemon.initializeDaemons
 
-fun main(args: Array<String>) = io.ktor.server.cio.EngineMain.main(args)
+fun main(args: Array<String>) {
+    io.ktor.server.cio.EngineMain.main(arrayOf(*args, "-config=application.conf", "-config=${System.getenv("AWS_SECRET_ARN")}"))
+}
 
 @Suppress("unused")
 fun Application.module() {

--- a/newm-server/src/main/kotlin/io/newm/server/aws/AwsSecretsManagerConfigLoader.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/aws/AwsSecretsManagerConfigLoader.kt
@@ -1,0 +1,66 @@
+package io.newm.server.aws
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerAsyncClientBuilder
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.config.ConfigLoader
+import io.ktor.server.config.HoconApplicationConfig
+import kotlinx.serialization.json.Json
+import java.io.File
+
+class AwsSecretsManagerConfigLoader : ConfigLoader {
+    private val secretsManager = AWSSecretsManagerAsyncClientBuilder.standard()
+        .withRegion(Regions.fromName("us-west-2"))
+        .build()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    override fun load(path: String?): ApplicationConfig? {
+        if ((path == null) || !path.startsWith("arn:aws:secretsmanager")) {
+            return null
+        }
+        val result = secretsManager.getSecretValue(
+            GetSecretValueRequest().withSecretId(path)
+        )
+        val secretsMap: Map<String, String> = json.decodeFromString(result.secretString)
+        val configString = convertToNestedHocon(secretsMap)
+
+        val file = File.createTempFile("temp", ".conf")
+        file.writeText(configString)
+        println(configString)
+        val config = ConfigFactory.parseFile(file)
+        file.delete()
+        return HoconApplicationConfig(config)
+    }
+}
+
+fun convertToNestedHocon(data: Map<String, Any>): String {
+    val stringBuilder = StringBuilder()
+
+    fun processKey(key: String, value: Any, indentLevel: Int) {
+        val indent = " ".repeat(indentLevel * 2)
+        val parts = key.split('.')
+        val currentKey = parts.first()
+        val remainingKey = parts.drop(1).joinToString(".")
+
+        stringBuilder.append("$indent$currentKey")
+        if (remainingKey.isNotEmpty()) {
+            stringBuilder.append(" {\n")
+            processKey(remainingKey, value, indentLevel + 1)
+            stringBuilder.append("$indent}")
+        } else {
+            stringBuilder.append(" = \"$value\"")
+        }
+        stringBuilder.append("\n")
+    }
+
+    for ((key, value) in data) {
+        processKey(key, value, 0)
+    }
+
+    return stringBuilder.toString()
+}

--- a/newm-server/src/main/resources/META-INF/services/io.ktor.server.config.ConfigLoader
+++ b/newm-server/src/main/resources/META-INF/services/io.ktor.server.config.ConfigLoader
@@ -1,0 +1,2 @@
+io.ktor.server.config.HoconConfigLoader
+io.newm.server.aws.AwsSecretsManagerConfigLoader


### PR DESCRIPTION
Initial draft of a custom config loader that loads secrets from SecretsManager at application start up. The advantage of a custom loader is that it eliminates the need for special handling via an extension function and also avoids defining excessive environment variables and hitting the 4K limit. This approach will "merge" the values from Secret manager into the config object at run time making secrets and non secret values available via a single config api.

This implementation works for basic use cases, but want to get feedback on the approach before continuing testing

self-comments in line as well