### PR TITLE
feat:Add working health checks

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -212,6 +212,10 @@ object Dependencies {
         const val CLOUDFRONT = "software.amazon.awssdk:cloudfront"
     }
 
+    object Zensum {
+        const val HEALTH_CHECK = "cc.rbbl:ktor-health-check:2.0.0"
+    }
+
     object Arweave {
         private const val ARWEAVE4S_VERSION = "0.21.0"
         private const val SCALA_JAVA8_COMPAT_VERSION = "1.0.2"

--- a/newm-server/build.gradle.kts
+++ b/newm-server/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(Dependencies.Exposed.DAO)
     implementation(Dependencies.Exposed.JDBC)
     implementation(Dependencies.Exposed.TIME)
+    implementation(Dependencies.Zensum.HEALTH_CHECK)
 
     implementation(Dependencies.HikariCP.ALL)
     implementation(Dependencies.PostgreSQL.ALL)

--- a/newm-server/src/main/kotlin/io/newm/server/Application.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/Application.kt
@@ -17,6 +17,7 @@ import io.newm.server.features.playlist.createPlaylistRoutes
 import io.newm.server.features.song.createSongRoutes
 import io.newm.server.features.user.createUserRoutes
 import io.newm.server.forwarder.installForwarder
+import io.newm.server.health.installHealthCheck
 import io.newm.server.logging.initializeSentry
 import io.newm.server.logging.installCallLogging
 import io.newm.server.staticcontent.createStaticContentRoutes
@@ -37,6 +38,7 @@ fun Application.module() {
     installStatusPages()
     installCORS()
     installForwarder()
+    installHealthCheck()
 
     routing {
         createStaticContentRoutes()

--- a/newm-server/src/main/kotlin/io/newm/server/health/HealthCheckInstall.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/health/HealthCheckInstall.kt
@@ -1,0 +1,41 @@
+package io.newm.server.health
+
+import cc.rbbl.ktor_health_check.Health
+import com.amazonaws.services.s3.AmazonS3
+import com.zaxxer.hikari.HikariDataSource
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationEnvironment
+import io.ktor.server.application.install
+import io.newm.shared.koin.inject
+import io.newm.shared.ktx.getConfigString
+
+// livez is the preferred endpoint over the deprecated healthz. We implement both for good measure.
+private const val HEALTHZ_CHECK_URL = "healthz"
+private const val LIVEZ_CHECK_URL = "livez"
+
+fun Health.Configuration.healthtechChecks() {
+    listOf(HEALTHZ_CHECK_URL, LIVEZ_CHECK_URL).forEach { endpoint ->
+        customCheck(endpoint, "status") {
+            true
+        }
+    }
+}
+
+fun Application.installHealthCheck() {
+    val hikariDataSource: HikariDataSource by inject()
+    val environment: ApplicationEnvironment by inject()
+    val s3: AmazonS3 by inject()
+
+    install(Health) {
+        healthtechChecks()
+
+        readyCheck("database") {
+            hikariDataSource.connection.isValid(5)
+        }
+
+        readyCheck("aws.s3") {
+            val bucketName = environment.getConfigString("aws.s3.agreement.bucketName")
+            s3.doesBucketExistV2(bucketName)
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces working health checks to verify the health and readiness of the service.  The implementation adopts the naming conventions from kubernetes (/livez, /ready) and provides only minimal checks to get started.  Checks will be expanded as we identify more checks to perform. 

/livez - check passes if service is up and running
/ready - more extensive checks to determine the service is behaving properly.
/healthz - an alias for /livez