### PR TITLE
feat:add auth url params to move away from cookies

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
@@ -4,7 +4,11 @@ import io.ktor.http.Cookie
 import io.newm.server.features.song.model.AudioStreamData
 import io.newm.server.security.PrivateKeyReader
 import software.amazon.awssdk.services.cloudfront.CloudFrontUtilities
+import software.amazon.awssdk.services.cloudfront.internal.url.DefaultSignedUrl
+import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest
+import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -20,11 +24,11 @@ class CloudfrontAudioStreamData(
     private val args: CloudfrontAudioStreamArguments
 ) : AudioStreamData {
     override val url: String
-        get() = this.args.url
+        get() = createSignedUrl(this.args.url)
     override val cookies: List<Cookie> by lazy { createSignedCookies() }
 
     private fun createSignedCookies(): List<Cookie> {
-        val streamUrl = this.url
+        val streamUrl = this.args.url
 
         // resource is the "dirname" of the URL with the filename removed,
         // effectively granting access to the entire "directory"
@@ -51,6 +55,45 @@ class CloudfrontAudioStreamData(
             cookie(name = keyPairIdHeaderName, value = keyPairIdHeaderValue),
             cookie(name = policyHeaderName, value = policyHeaderValue),
         )
+    }
+
+    private fun createSignedUrl(streamUrl: String): String {
+        // resource is the "dirname" of the URL with the filename removed,
+        // effectively granting access to the entire "directory"
+        val resourceUrl = "${streamUrl.removeRange(streamUrl.lastIndexOf("/"), streamUrl.length)}/*"
+        val request = CustomSignerRequest.builder()
+            .resourceUrl(resourceUrl)
+            .privateKey(PrivateKeyReader.readFromString(args.privateKey))
+            .keyPairId(args.keyPairId)
+            .expirationDate(args.expirationDate)
+            // optional
+            //  .activeDate(activeDate)
+            //  .ipRange("192.168.0.1/24")
+            .build()
+
+        val policy = SigningUtils.buildCustomPolicyForSignedUrl(
+            request.resourceUrl(),
+            request.activeDate(),
+            request.expirationDate(),
+            request.ipRange()
+        )
+        val signatureBytes =
+            SigningUtils.signWithSha1Rsa(policy.toByteArray(StandardCharsets.UTF_8), request.privateKey())
+        val urlSafePolicy = SigningUtils.makeStringUrlSafe(policy)
+        val urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes)
+        val uri = URI.create(streamUrl)
+        val protocol = uri.scheme
+        val domain = uri.host
+        val encodedPath = (
+            uri.rawPath +
+                (if (uri.getQuery() != null) "?" + uri.rawQuery + "&" else "?") +
+                "Policy=" + urlSafePolicy +
+                "&Signature=" + urlSafeSignature +
+                "&Key-Pair-Id=" + request.keyPairId()
+            )
+        val signedUrl = DefaultSignedUrl.builder().protocol(protocol).domain(domain).encodedPath(encodedPath)
+            .url("$protocol://$domain$encodedPath").build()
+        return signedUrl.url()
     }
 
     private fun cookie(name: String, value: String): Cookie = Cookie(

--- a/newm-server/src/test/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamDataTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamDataTest.kt
@@ -21,6 +21,14 @@ class CloudfrontAudioStreamDataTest : BaseApplicationTests() {
             this.privateKey = pk
         }
 
+        val url = streamData.url
+        val cookies = streamData.cookies
+        println("url=$url")
+        assertThat(streamData.url).contains("https://newm.io/path/filename.m3u8?")
+        assertThat(streamData.url).contains("Policy=")
+        assertThat(streamData.url).contains("Key-Pair-Id=")
+        assertThat(streamData.url).contains("Signature=")
+
         assertThat(streamData.cookies.filter { it.name == "CloudFront-Key-Pair-Id" }).isNotEmpty()
         assertThat(streamData.cookies.filter { it.name == "CloudFront-Signature" }).isNotEmpty()
         assertThat(streamData.cookies.filter { it.name == "CloudFront-Policy" }).isNotEmpty()


### PR DESCRIPTION
First step of enabling signed url params is to return them in the m3u8 url.