### PR TITLE
CU-86a0vf8pv: Ensure release_date has enough time during distribution

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepository.kt
@@ -2,6 +2,7 @@ package io.newm.server.features.song.repo
 
 import io.ktor.utils.io.ByteReadChannel
 import io.newm.chain.grpc.Utxo
+import io.newm.server.features.song.database.SongEntity
 import io.newm.server.features.song.model.AudioStreamData
 import io.newm.server.features.song.model.AudioUploadReport
 import io.newm.server.features.song.model.MintingStatus
@@ -39,4 +40,6 @@ interface SongRepository {
     suspend fun updateSongMintingStatus(songId: UUID, mintingStatus: MintingStatus)
 
     suspend fun distribute(songId: UUID)
+
+    abstract fun set(songId: UUID, editor: (SongEntity) -> Unit)
 }

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
@@ -170,6 +170,14 @@ internal class SongRepositoryImpl(
         }
     }
 
+    override fun set(songId: UUID, editor: (SongEntity) -> Unit) {
+        logger.debug { "editFields: songId = $songId" }
+        transaction {
+            val entity = SongEntity[songId]
+            editor(entity)
+        }
+    }
+
     override suspend fun delete(songId: UUID, requesterId: UUID) {
         logger.debug { "delete: songId = $songId, requesterId = $requesterId" }
         transaction {


### PR DESCRIPTION
If we ever have to re-process a song and some days have passed, ensure that the release date gets updated to still give the distributor enough time to review it. Otherwise, they just reject it a second time.