### PR TITLE
feat: Cloudfront strips the "Policy","Key-Pair-Id" and "Signature" qu…

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamData.kt
@@ -88,8 +88,11 @@ class CloudfrontAudioStreamData(
             uri.rawPath +
                 (if (uri.getQuery() != null) "?" + uri.rawQuery + "&" else "?") +
                 "Policy=" + urlSafePolicy +
+                "&oPolicy=" + urlSafePolicy +
                 "&Signature=" + urlSafeSignature +
-                "&Key-Pair-Id=" + request.keyPairId()
+                "&oSignature=" + urlSafeSignature +
+                "&Key-Pair-Id=" + request.keyPairId() +
+                "&oKey-Pair-Id=" + request.keyPairId()
             )
         val signedUrl = DefaultSignedUrl.builder().protocol(protocol).domain(domain).encodedPath(encodedPath)
             .url("$protocol://$domain$encodedPath").build()

--- a/newm-server/src/test/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamDataTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/aws/cloudfront/CloudfrontAudioStreamDataTest.kt
@@ -22,7 +22,6 @@ class CloudfrontAudioStreamDataTest : BaseApplicationTests() {
         }
 
         val url = streamData.url
-        val cookies = streamData.cookies
         println("url=$url")
         assertThat(streamData.url).contains("https://newm.io/path/filename.m3u8?")
         assertThat(streamData.url).contains("Policy=")


### PR DESCRIPTION
…ery params from signed urls

so sending the same values in params with different names in order to pass the values the origin. Passing the values to the orign means that we can avoid re-signing URLs and hopefully reduce latency.