### PR TITLE
Fix some CIP68 NFT datum parsing

### DIFF
--- a/newm-chain/src/test/kotlin/io/newm/chain/cardano/Cip68DatumTest.kt
+++ b/newm-chain/src/test/kotlin/io/newm/chain/cardano/Cip68DatumTest.kt
@@ -1,13 +1,29 @@
 package io.newm.chain.cardano
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import com.google.common.truth.Truth.assertThat
+import io.newm.chain.config.Config
 import io.newm.chain.database.entity.LedgerAsset
 import io.newm.chain.model.CreatedUtxo
 import io.newm.chain.model.NativeAsset
 import io.newm.chain.util.extractAssetMetadata
+import io.newm.chain.util.toCreatedUtxoSet
+import io.newm.kogmios.Client
+import io.newm.kogmios.StateQueryClient
+import io.newm.kogmios.createChainSyncClient
+import io.newm.kogmios.protocols.messages.IntersectionFound
+import io.newm.kogmios.protocols.messages.RollBackward
+import io.newm.kogmios.protocols.messages.RollForward
+import io.newm.kogmios.protocols.model.CompactGenesis
 import io.newm.kogmios.protocols.model.MetadataMap
+import io.newm.kogmios.protocols.model.PointDetail
 import io.newm.txbuilder.ktx.cborHexToPlutusData
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.math.BigInteger
 
 class Cip68DatumTest {
@@ -43,12 +59,86 @@ class Cip68DatumTest {
         assertThat(ledgerAssetMetadata).isNotEmpty()
     }
 
+    @Test
+    @Disabled("This test requires a running ogmios instance")
+    fun testDerpBirdsOutpostsCIP68() = runBlocking {
+        val root: Logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger
+        root.level = Level.INFO
+
+        createChainSyncClient(
+            websocketHost = "localhost",
+            websocketPort = 1337,
+            secure = false,
+            ogmiosCompact = false,
+        ).use { client ->
+            val connectResult = client.connect()
+            if (!connectResult) {
+                throw IOException("client.connect() was false!")
+            }
+            if (!client.isConnected) {
+                throw IOException("client.isConnected was false!")
+            }
+            (client as StateQueryClient).genesisConfig().let { genesisConfig ->
+                Config.genesis = genesisConfig.result as CompactGenesis
+            }
+
+            val msgFindIntersectResponse = client.findIntersect(
+                listOf(
+                    PointDetail(
+                        105659354L,
+                        "7ebe1503ca9119343d06e56fd0048e0b0cd1873dbaaaf7d5039235558808219c"
+                    )
+                )
+            )
+            if (msgFindIntersectResponse.result !is IntersectionFound) {
+                throw IllegalStateException("Error finding blockchain intersect!")
+            }
+
+            var shouldContinue = true
+            while (shouldContinue) {
+                val response = client.requestNext(timeoutMs = Client.DEFAULT_REQUEST_TIMEOUT_MS)
+                when (response.result) {
+                    is RollBackward -> {
+                        println("RollBackward: ${(response.result as RollBackward).rollBackward.point}")
+                    }
+
+                    is RollForward -> {
+                        (response.result as RollForward).rollForward.let { rollForward ->
+                            val block = rollForward.block
+                            val createdUtxos = block.toCreatedUtxoSet()
+                            require(createdUtxos.isNotEmpty()) { "createdUtxos is empty!" }
+                            // Save metadata for CIP-68 reference metadata appearing on createdUtxos datum values
+                            val nativeAssetMetadataList = cip68UtxoOutputsTo721MetadataMap(createdUtxos)
+                            require(nativeAssetMetadataList.isNotEmpty()) { "nativeAssetMetadataList is empty!" }
+                            nativeAssetMetadataList.forEach { (metadataMap, assetList) ->
+                                try {
+                                    val assetMetadatas = metadataMap.extractAssetMetadata(assetList)
+                                    println(assetMetadatas)
+                                } catch (e: Throwable) {
+                                    println("metadataError at block ${block.header.blockHeight}, metadataMap: $metadataMap, assetList: $assetList")
+                                    throw e
+                                }
+                            }
+                            shouldContinue = false
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private fun cip68UtxoOutputsTo721MetadataMap(createdUtxos: Set<CreatedUtxo>): List<Pair<MetadataMap, List<LedgerAsset>>> {
+        var i = 1L
         return createdUtxos.filter { createdUtxo ->
             createdUtxo.nativeAssets.any { nativeAsset ->
-                nativeAsset.name.matches(CIP68_REFERENCE_TOKEN_REGEX)
+                nativeAsset.name.matches(CIP68_REFERENCE_TOKEN_REGEX).also {
+                    if (it) {
+                        println("found: ${nativeAsset.policy}.${nativeAsset.name}")
+                    }
+                }
             }
         }.mapNotNull { cip68CreatedUtxo ->
+            println("cip68CreatedUtxo: $cip68CreatedUtxo")
             cip68CreatedUtxo.datum?.let { datum ->
                 val cip68PlutusData = datum.cborHexToPlutusData()
                 if (cip68PlutusData.hasConstr() && cip68PlutusData.constr == 0) {
@@ -57,7 +147,13 @@ class Cip68DatumTest {
                     }.map { nativeAsset ->
                         val metadataMap = cip68PlutusData.toMetadataMap(nativeAsset.policy, nativeAsset.name)
                         metadataMap to cip68CreatedUtxo.nativeAssets.map { na ->
-                            LedgerAsset(1, na.policy, na.name, BigInteger.ONE)
+                            // dummy in the data
+                            LedgerAsset(
+                                id = i++,
+                                policy = na.policy,
+                                name = na.name,
+                                supply = BigInteger.ONE
+                            )
                         }
                     }
                 } else {


### PR DESCRIPTION
Some CIP68 NFTs store their datum value down in the witness set instead of inline with the tx body. Make sure we grab the datum value for these NFTs in that case.