### PR TITLE
Add retry to eveara token fetch

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ServerResponseException
+import io.ktor.client.plugins.retry
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.accept
 import io.ktor.client.request.bearerAuth
@@ -180,6 +181,10 @@ class EvearaDistributionRepositoryImpl(
                 }
             } ?: run {
                 val response = httpClient.post("$evearaApiBaseUrl/oauth/gettoken") {
+                    retry {
+                        maxRetries = 2
+                        delayMillis { 500L }
+                    }
                     contentType(ContentType.Application.Json)
                     accept(ContentType.Application.Json)
                     setBody(


### PR DESCRIPTION
Saw some random errors:

```
POST https://staging.eveara.com/api/v2.1/oauth/gettoken: 500 URL Rewrite Module Error.. Text: "Error getting Eveara accessToken! - "
```

After reprocessing those songs, we got access token ok and they went through. When we are trying to get an access token, we should give it more than one shot since this is important.