### PR TITLE
Decrease minting costs

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/minting/repo/MintingRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/minting/repo/MintingRepositoryImpl.kt
@@ -19,6 +19,7 @@ import io.newm.chain.grpc.plutusDataMap
 import io.newm.chain.grpc.plutusDataMapItem
 import io.newm.chain.grpc.redeemer
 import io.newm.chain.grpc.signature
+import io.newm.chain.util.Blake2b
 import io.newm.chain.util.Sha3
 import io.newm.chain.util.hexToByteArray
 import io.newm.server.config.repo.ConfigRepository
@@ -254,7 +255,7 @@ class MintingRepositoryImpl(
                             amount = "1"
                         }
                     )
-                    datum = cip68Metadata.toCborObject().toCborByteArray().toHexString()
+                    datumHash = Blake2b.hash256(cip68Metadata.toCborObject().toCborByteArray()).toHexString()
                 }
             )
 
@@ -338,6 +339,10 @@ class MintingRepositoryImpl(
                 // }
             }
         )
+
+        with(datums) {
+            add(cip68Metadata)
+        }
 
         // Add a simple transaction metadata note for NEWM Mint - See: CIP-20
         transactionMetadataCbor = ByteString.copyFrom(

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
@@ -391,12 +391,15 @@ internal class SongRepositoryImpl(
         // Save the mint cost to the database
         update(songId, Song(mintCostLovelace = mintCostLovelace))
 
+        // usdPrice does not include the extra changeAmountLovelace that we request the wallet to provide as it
+        // is returned to the user.
         val usdPrice = (
             cardanoRepository.queryAdaUSDPrice()
-                .toBigInteger() * (mintCostLovelace + changeAmountLovelace).toBigInteger()
-            ).div(1000000.toBigInteger())
+                .toBigInteger() * mintCostLovelace.toBigInteger()
+            ) / 1000000.toBigInteger()
 
         return Pair(
+            // we send an extra changeAmountLovelace to ensure we have enough ada to cover a return utxo
             CborInteger.create(mintCostLovelace + changeAmountLovelace).toCborByteArray().toHexString(),
             usdPrice
         )

--- a/newm-server/src/test/kotlin/io/newm/server/features/song/SongRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/song/SongRoutesTests.kt
@@ -857,7 +857,7 @@ class SongRoutesTests : BaseApplicationTests() {
         val actualCborHex = responseBody.cborHex
         val expectedCborHex = CborInteger.create(expectedAmount + 1000000L).toCborByteArray().toHexString()
         assertThat(actualCborHex).isEqualTo(expectedCborHex)
-        assertThat(responseBody.usdPrice).isEqualTo(1773800.toBigInteger()) // $1.7738
+        assertThat(responseBody.usdPrice).isEqualTo(1520400.toBigInteger()) // $1.5204
     }
 
     @Test


### PR DESCRIPTION
Try switching from inline datum to offline datum values to reduce the cost since we don't hold the metadata in the active ledger.