### PR TITLE
Attempt to fix SQS receive hanging 2

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/daemon/AwsSqsDaemon.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/daemon/AwsSqsDaemon.kt
@@ -53,13 +53,13 @@ class AwsSqsDaemon : Daemon {
                 val delayTimeMs = getLong("delayTimeMs")
                 val receiverClass = Class.forName(getString("receiver"))
                 val receiver = receiverClass.kotlin.primaryConstructor!!.call() as SqsMessageReceiver
-                val request = ReceiveMessageRequest()
-                    .withQueueUrl(queueUrl)
-                    .withWaitTimeSeconds(waitTime)
-                    .withMaxNumberOfMessages(1)
                 log.info { "SQS Listening on $queueUrl -> ${receiverClass.simpleName}" }
                 while (true) {
                     try {
+                        val request = ReceiveMessageRequest()
+                            .withQueueUrl(queueUrl)
+                            .withWaitTimeSeconds(waitTime)
+                            .withMaxNumberOfMessages(1)
                         val result = request.await()
                         log.debug { "$queueUrl -> Received ${result.messages.size} SQS messages" }
                         for (message in result.messages) {


### PR DESCRIPTION
Create a new Request object each time we loop so we clear the `receiveRequestAttemptId` that is automatically generated internally by AWS sqs library. 