### PR TITLE
Fix npe for json parsing

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
@@ -1453,7 +1453,7 @@ class EvearaDistributionRepositoryImpl(
         val desiredLabelName = song.phonographicCopyrightOwner ?: user.companyOrStageOrFullName
         val getUserLabelsResponse = getUserLabel(user)
         if (getUserLabelsResponse.totalRecords > 1) {
-            val existingLabel = getUserLabelsResponse.userLabelData!!.first { it.name != "NEWM" } // TODO: FIX hardcoding
+            val existingLabel = getUserLabelsResponse.userLabelData.first { it.name != "NEWM" } // TODO: FIX hardcoding
             log.info { "Found existing distribution label ${user.email} with id ${existingLabel.labelId}, name ${existingLabel.name}" }
             if (user.distributionLabelId == null) {
                 user.distributionLabelId = existingLabel.labelId

--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/model/GetUserLabelResponse.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/model/GetUserLabelResponse.kt
@@ -12,5 +12,5 @@ data class GetUserLabelResponse(
     @SerialName("total_records")
     val totalRecords: Long,
     @SerialName("data")
-    val userLabelData: List<UserLabelData>? = null
+    val userLabelData: List<UserLabelData>
 )

--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/model/UserLabelData.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/model/UserLabelData.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UserLabelData(
     @SerialName("releases")
-    val releases: Int,
+    val releases: Int? = null,
     @SerialName("label_id")
     val labelId: Long? = null,
     @SerialName("is_active")


### PR DESCRIPTION
Actual data is possible to not have the "releases" field inside the data object.
```
{
    "message": "Currently showing 1 record(s)",
    "success": true,
    "total_records": 1,
    "data": [
        {
            "label_id": 79308,
            "is_active": 1,
            "removable": true,
            "name": "NEWM"
        }
    ]
}
```