### PR TITLE
Ensure we can save null-containing metadata keys

### DIFF
--- a/newm-chain-db/src/main/kotlin/io/newm/chain/database/repository/LedgerRepositoryImpl.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/database/repository/LedgerRepositoryImpl.kt
@@ -597,7 +597,7 @@ class LedgerRepositoryImpl : LedgerRepository {
         val id = LedgerAssetMetadataTable.insertAndGetId {
             it[assetId] = ledgerAssetMetadata.assetId
             it[keyType] = ledgerAssetMetadata.keyType
-            it[key] = ledgerAssetMetadata.key
+            it[key] = ledgerAssetMetadata.key.replace("\u0000", "\\u0000")
             it[valueType] = ledgerAssetMetadata.valueType
             it[value] = ledgerAssetMetadata.value.replace("\u0000", "\\u0000")
             it[nestLevel] = ledgerAssetMetadata.nestLevel


### PR DESCRIPTION
Axo trade launch exposed how someone could put a null character into their metadata key and not just their metadata value. postgresql chokes on this so we escape it before it gets inserted.