### PR TITLE
MOBILE-154: Pass xpub key errors back from newmchain

### DIFF
--- a/newm-chain-grpc/src/main/proto/newm_chain.proto
+++ b/newm-chain-grpc/src/main/proto/newm_chain.proto
@@ -331,6 +331,7 @@ message Address {
 
 message QueryWalletControlledUtxosResponse {
   repeated AddressUtxos address_utxos = 1;
+  optional string error_message = 2;
 }
 
 message AddressUtxos {

--- a/newm-server/src/main/kotlin/io/newm/server/features/cardano/repo/CardanoRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/cardano/repo/CardanoRepositoryImpl.kt
@@ -358,11 +358,15 @@ internal class CardanoRepositoryImpl(
     }
 
     private suspend fun getWalletAssets(xpubKey: String): List<NativeAsset> {
-        return client.queryWalletControlledLiveUtxos(
-            walletRequest {
-                accountXpubKey = xpubKey
-            }
-        ).addressUtxosList.flatMap {
+        val response =
+            client.queryWalletControlledLiveUtxos(
+                walletRequest {
+                    accountXpubKey = xpubKey
+                }
+            )
+        require(!response.hasErrorMessage()) { "Error querying wallet controlled utxos: ${response.errorMessage}" }
+
+        return response.addressUtxosList.flatMap {
             it.utxosList.flatMap(Utxo::getNativeAssetsList)
         }.mergeAmounts()
     }


### PR DESCRIPTION
If something is wrong with the xpub key, we just get generic `io.grpc.StatusException: UNKNOWN` errors back on newm-server from newm-chain. This code captures errors and passes them back in an error_message field so we can throw the error on the newm-server side with something that makes sense.