### PR TITLE
STUD-97: Create tables for royalty claiming

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/Application.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/Application.kt
@@ -12,6 +12,7 @@ import io.newm.server.features.cardano.createCardanoRoutes
 import io.newm.server.features.cloudinary.createCloudinaryRoutes
 import io.newm.server.features.collaboration.createCollaborationRoutes
 import io.newm.server.features.distribution.createDistributionRoutes
+import io.newm.server.features.earnings.createEarningsRoutes
 import io.newm.server.features.idenfy.createIdenfyRoutes
 import io.newm.server.features.playlist.createPlaylistRoutes
 import io.newm.server.features.song.createSongRoutes
@@ -51,6 +52,7 @@ fun Application.module() {
         createCloudinaryRoutes()
         createIdenfyRoutes()
         createDistributionRoutes()
+        createEarningsRoutes()
     }
 
     initializeDaemons()

--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V45__CreateEarnings.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V45__CreateEarnings.kt
@@ -1,0 +1,50 @@
+package io.newm.server.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("unused")
+class V45__CreateEarnings : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            execInBatch(
+                listOf(
+                    """
+                    CREATE TABLE IF NOT EXISTS earnings
+                    (
+                        id uuid PRIMARY KEY,
+                        song_id uuid,
+                        stake_address text NOT NULL,
+                        amount bigint NOT NULL,
+                        memo text NOT NULL,
+                        start_date timestamp without time zone,
+                        end_date timestamp without time zone,
+                        claimed boolean NOT NULL DEFAULT FALSE,
+                        claimed_at timestamp without time zone,
+                        claim_order_id uuid,
+                        created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT fk_earnings_song_id__id FOREIGN KEY (song_id) REFERENCES songs (id) ON UPDATE RESTRICT ON DELETE RESTRICT
+                    )
+                    """.trimIndent(),
+                    """
+                    CREATE TABLE IF NOT EXISTS claim_orders
+                    (
+                        id uuid PRIMARY KEY,
+                        stake_address text NOT NULL,
+                        key_id uuid NOT NULL,
+                        status text NOT NULL,
+                        earnings_ids uuid ARRAY NOT NULL,
+                        failed_earnings_ids uuid ARRAY,
+                        transaction_id text,
+                        created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT fk_claim_orders_key_id__id FOREIGN KEY (key_id) REFERENCES keys (id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+                        CONSTRAINT fk_claim_orders_earnings_ids__id FOREIGN KEY (earnings_ids) REFERENCES earnings (id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+                        CONSTRAINT fk_claim_orders_failed_earnings_ids__id FOREIGN KEY (failed_earnings_ids) REFERENCES earnings (id) ON UPDATE RESTRICT ON DELETE RESTRICT
+                    )
+                    """.trimIndent(),
+                )
+            )
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/di/DependencyInjectionInstall.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/di/DependencyInjectionInstall.kt
@@ -13,6 +13,7 @@ import io.newm.server.features.cloudinary.cloudinaryKoinModule
 import io.newm.server.features.collaboration.collaborationKoinModule
 import io.newm.server.features.daemon.daemonsKoinModule
 import io.newm.server.features.distribution.distributionKoinModule
+import io.newm.server.features.earnings.earningsKoinModule
 import io.newm.server.features.email.emailKoinModule
 import io.newm.server.features.idenfy.idenfyKoinModule
 import io.newm.server.features.minting.mintingKoinModule
@@ -56,6 +57,7 @@ fun Application.installDependencyInjection() {
             arweaveKoinModule,
             mintingKoinModule,
             releaseKoinModule,
+            earningsKoinModule,
         )
     }
 }

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/EarningsKoinModule.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/EarningsKoinModule.kt
@@ -1,0 +1,9 @@
+package io.newm.server.features.earnings
+
+import io.newm.server.features.earnings.repo.EarningsRepositoryImpl
+import org.koin.dsl.module
+
+val earningsKoinModule =
+    module {
+        single { EarningsRepositoryImpl() }
+    }

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/EarningsRoutes.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/EarningsRoutes.kt
@@ -1,0 +1,47 @@
+package io.newm.server.features.earnings
+
+import io.ktor.server.auth.authenticate
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.route
+import io.newm.chain.util.extractStakeAddress
+import io.newm.server.auth.jwt.AUTH_JWT
+import io.newm.server.auth.jwt.AUTH_JWT_ADMIN
+import io.newm.server.features.cardano.repo.CardanoRepository
+import io.newm.server.features.earnings.repo.EarningsRepository
+import io.newm.shared.koin.inject
+import io.newm.shared.ktx.get
+import io.newm.shared.ktx.post
+
+private const val EARNINGS_PATH = "v1/earnings"
+
+fun Routing.createEarningsRoutes() {
+    val cardanoRepository: CardanoRepository by inject()
+    val earningsRepository: EarningsRepository by inject()
+
+    authenticate(AUTH_JWT_ADMIN) {
+        route(EARNINGS_PATH) {
+            // create earning records
+            post {
+                TODO()
+            }
+        }
+    }
+    authenticate(AUTH_JWT) {
+        route("$EARNINGS_PATH/{walletAddress}") {
+            // get earnings
+            get {
+                val stakeAddress = parameters["walletAddress"]!!.extractStakeAddress(cardanoRepository.isMainnet())
+                val earnings = earningsRepository.getAllByStakeAddress(stakeAddress)
+                TODO()
+            }
+            // create a claim for all earnings on this wallet stake address
+            post {
+                val stakeAddress = parameters["walletAddress"]!!.extractStakeAddress(cardanoRepository.isMainnet())
+                // check for existing open claim record first
+                // TODO
+                // create a new claim record
+                TODO()
+            }
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/ClaimOrderEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/ClaimOrderEntity.kt
@@ -1,0 +1,32 @@
+package io.newm.server.features.earnings.database
+
+import io.newm.server.features.earnings.model.ClaimOrder
+import io.newm.server.features.earnings.model.ClaimOrderStatus
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import java.util.UUID
+
+class ClaimOrderEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    var stakeAddress by ClaimOrdersTable.stakeAddress
+    var keyId by ClaimOrdersTable.keyId
+    var status by ClaimOrdersTable.status
+    var earningsIds by ClaimOrdersTable.earningsIds
+    var failedEarningsIds by ClaimOrdersTable.failedEarningsIds
+    var transactionId by ClaimOrdersTable.transactionId
+    var createdAt by ClaimOrdersTable.createdAt
+
+    fun toModel() =
+        ClaimOrder(
+            id = id.value,
+            stakeAddress = stakeAddress,
+            keyId = keyId.value,
+            status = ClaimOrderStatus.valueOf(status),
+            earningsIds = earningsIds.toList(),
+            failedEarningsIds = failedEarningsIds?.toList(),
+            transactionId = transactionId,
+            createdAt = createdAt
+        )
+
+    companion object : UUIDEntityClass<ClaimOrderEntity>(ClaimOrdersTable)
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/ClaimOrdersTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/ClaimOrdersTable.kt
@@ -1,0 +1,35 @@
+package io.newm.server.features.earnings.database
+
+import io.newm.server.features.cardano.database.KeyTable
+import io.newm.shared.exposed.uuidArray
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
+import org.jetbrains.exposed.sql.javatime.datetime
+import java.time.LocalDateTime
+import java.util.UUID
+
+object ClaimOrdersTable : UUIDTable(name = "claim_orders") {
+    // The user's stake address
+    val stakeAddress: Column<String> = text("stake_address")
+
+    // The key/address used to receive payment for the claiming transaction
+    val keyId: Column<EntityID<UUID>> = reference("key_id", KeyTable, onDelete = ReferenceOption.RESTRICT)
+
+    // The status of the claim order
+    val status: Column<String> = text("status")
+
+    // The IDs of the earnings that are being claimed
+    val earningsIds: Column<Array<UUID>> = uuidArray("earnings_ids")
+
+    // The IDs of the earnings that failed to be claimed (bucket ran dry or some other error)
+    val failedEarningsIds: Column<Array<UUID>?> = uuidArray("failed_earnings_ids").nullable()
+
+    // The transaction ID of the claiming transaction
+    val transactionId: Column<String?> = text("transaction_id").nullable()
+
+    // The time the claim order was created
+    val createdAt: Column<LocalDateTime> = datetime("created_at").defaultExpression(CurrentDateTime)
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/EarningEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/EarningEntity.kt
@@ -1,0 +1,39 @@
+package io.newm.server.features.earnings.database
+
+import io.newm.server.features.earnings.model.Earning
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import java.time.LocalDateTime
+import java.util.UUID
+
+class EarningEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    var songId: EntityID<UUID>? by EarningsTable.songId
+    var stakeAddress: String by EarningsTable.stakeAddress
+    var amount: Long by EarningsTable.amount
+    var memo: String by EarningsTable.memo
+    var startDate: LocalDateTime? by EarningsTable.startDate
+    var endDate: LocalDateTime? by EarningsTable.endDate
+    var claimed: Boolean by EarningsTable.claimed
+    var claimedAt: LocalDateTime? by EarningsTable.claimedAt
+    var claimOrderId: EntityID<UUID>? by EarningsTable.claimedOrderId
+    var createdAt: LocalDateTime by EarningsTable.createdAt
+
+    fun toModel(): Earning =
+        Earning(
+            id = id.value,
+            songId = songId?.value,
+            stakeAddress = stakeAddress,
+            amount = amount,
+            memo = memo,
+            startDate = startDate,
+            endDate = endDate,
+            claimed = claimed,
+            claimedAt = claimedAt,
+            claimOrderId = claimOrderId?.value,
+            createdAt = createdAt,
+        )
+
+    companion object : UUIDEntityClass<EarningEntity>(EarningsTable) {
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/EarningsTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/EarningsTable.kt
@@ -1,0 +1,31 @@
+package io.newm.server.features.earnings.database
+
+import io.newm.server.features.song.database.SongTable
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
+import org.jetbrains.exposed.sql.javatime.datetime
+import java.time.LocalDateTime
+import java.util.UUID
+
+object EarningsTable : UUIDTable(name = "earnings") {
+    val songId: Column<EntityID<UUID>?> =
+        reference("song_id", SongTable, onDelete = ReferenceOption.RESTRICT).nullable()
+    val stakeAddress: Column<String> = text("stake_address")
+    val amount: Column<Long> = long("amount")
+    val memo: Column<String> = text("memo")
+    val startDate: Column<LocalDateTime?> = datetime("start_date").nullable()
+    val endDate: Column<LocalDateTime?> = datetime("end_date").nullable()
+    val claimed: Column<Boolean> = bool("claimed").default(false)
+    val claimedAt: Column<LocalDateTime?> = datetime("claimed_at").nullable()
+    val claimedOrderId: Column<EntityID<UUID>?> =
+        reference(
+            "claimed_order_id",
+            ClaimOrdersTable,
+            onUpdate = ReferenceOption.RESTRICT,
+            onDelete = ReferenceOption.RESTRICT
+        ).nullable()
+    val createdAt: Column<LocalDateTime> = datetime("created_at").defaultExpression(CurrentDateTime)
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrder.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrder.kt
@@ -1,0 +1,28 @@
+package io.newm.server.features.earnings.model
+
+import io.newm.shared.serialization.LocalDateTimeSerializer
+import io.newm.shared.serialization.UUIDSerializer
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Serializable
+data class ClaimOrder(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID,
+    val stakeAddress: String,
+    @Serializable(with = UUIDSerializer::class)
+    val keyId: UUID,
+    val status: ClaimOrderStatus,
+    val earningsIds: List<
+        @Serializable(with = UUIDSerializer::class)
+        UUID
+    >,
+    val failedEarningsIds: List<
+        @Serializable(with = UUIDSerializer::class)
+        UUID
+    >?,
+    val transactionId: String?,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val createdAt: LocalDateTime
+)

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrderStatus.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrderStatus.kt
@@ -1,0 +1,22 @@
+package io.newm.server.features.earnings.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class ClaimOrderStatus {
+    @SerialName("Pending")
+    Pending,
+
+    @SerialName("Processing")
+    Processing,
+
+    @SerialName("Completed")
+    Completed,
+
+    @SerialName("Timeout")
+    Timeout,
+
+    @SerialName("Blocked")
+    Blocked,
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/Earning.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/Earning.kt
@@ -1,0 +1,33 @@
+package io.newm.server.features.earnings.model
+
+import io.newm.shared.serialization.LocalDateTimeSerializer
+import io.newm.shared.serialization.UUIDSerializer
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * An earning is any type of reward earned by the user. It could be a music royalty from stream tokens. It could also be
+ * a reward they earned from the learn-to-earn program or any general marketing team reward we do.
+ */
+@Serializable
+data class Earning(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID? = null,
+    @Serializable(with = UUIDSerializer::class)
+    val songId: UUID? = null,
+    val stakeAddress: String,
+    val amount: Long,
+    val memo: String,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val startDate: LocalDateTime? = null,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val endDate: LocalDateTime? = null,
+    val claimed: Boolean = false,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val claimedAt: LocalDateTime? = null,
+    @Serializable(with = UUIDSerializer::class)
+    val claimOrderId: UUID? = null,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val createdAt: LocalDateTime
+)

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/repo/EarningsRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/repo/EarningsRepository.kt
@@ -1,0 +1,30 @@
+package io.newm.server.features.earnings.repo
+
+import io.newm.server.features.earnings.model.ClaimOrder
+import io.newm.server.features.earnings.model.Earning
+import java.util.UUID
+
+interface EarningsRepository {
+    /**
+     * Add a new earning
+     */
+    suspend fun add(earning: Earning): UUID
+
+    /**
+     * Add a new claim order
+     */
+    suspend fun add(claimOrder: ClaimOrder): UUID
+
+    /**
+     * Mark the earnings as claimed by a claim order
+     */
+    suspend fun claimed(
+        earningIds: List<UUID>,
+        claimOrderId: UUID
+    )
+
+    /**
+     * Get all earnings by stake address
+     */
+    suspend fun getAllByStakeAddress(stakeAddress: String): List<Earning>
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/repo/EarningsRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/repo/EarningsRepositoryImpl.kt
@@ -1,0 +1,62 @@
+package io.newm.server.features.earnings.repo
+
+import io.newm.server.features.cardano.database.KeyTable
+import io.newm.server.features.earnings.database.ClaimOrderEntity
+import io.newm.server.features.earnings.database.ClaimOrdersTable
+import io.newm.server.features.earnings.database.EarningEntity
+import io.newm.server.features.earnings.model.ClaimOrder
+import io.newm.server.features.earnings.model.Earning
+import io.newm.server.features.song.database.SongTable
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
+import java.util.UUID
+
+class EarningsRepositoryImpl : EarningsRepository {
+    override suspend fun add(earning: Earning): UUID =
+        transaction {
+            EarningEntity.new {
+                this.songId = earning.songId?.let { EntityID(it, SongTable) }
+                this.stakeAddress = earning.stakeAddress
+                this.amount = earning.amount
+                this.memo = earning.memo
+                this.startDate = earning.startDate
+                this.endDate = earning.endDate
+                this.claimed = earning.claimed
+                this.claimedAt = earning.claimedAt
+                this.claimOrderId = earning.claimOrderId?.let { EntityID(it, ClaimOrdersTable) }
+                this.createdAt = earning.createdAt
+            }.id.value
+        }
+
+    override suspend fun add(claimOrder: ClaimOrder): UUID =
+        transaction {
+            ClaimOrderEntity.new {
+                this.stakeAddress = claimOrder.stakeAddress
+                this.keyId = EntityID(claimOrder.keyId, KeyTable)
+                this.status = claimOrder.status.name
+                this.earningsIds = claimOrder.earningsIds.toTypedArray()
+                this.failedEarningsIds = claimOrder.failedEarningsIds?.toTypedArray()
+                this.transactionId = claimOrder.transactionId
+                this.createdAt = claimOrder.createdAt
+            }.id.value
+        }
+
+    override suspend fun claimed(
+        earningIds: List<UUID>,
+        claimOrderId: UUID
+    ) {
+        transaction {
+            val claimedAt = LocalDateTime.now()
+            EarningEntity.forIds(earningIds).forUpdate().forEach {
+                it.claimed = true
+                it.claimOrderId = EntityID(claimOrderId, ClaimOrdersTable)
+                it.claimedAt = claimedAt
+            }
+        }
+    }
+
+    override suspend fun getAllByStakeAddress(stakeAddress: String): List<Earning> {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
I called the table "earnings" given that royalties are just one type of thing that can be claimed. Learn to earn rewards or referral rewards might also be included in a user's claimable earnings.

The earnings table holds are records of newmies that are allowed to be claimed by a given staking address. The claim_orders table holds a record that gets created when the user goes to claim. We create a payment address that is monitored for payment for a period of time before timing out. If payment is received, we will then create the transaction to send the user's earnings to them.

This first PR is just the creating of the database.