### PR TITLE
STUD-161: Ensure we only upload tracks to eveara once

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V47__CollaborationsUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V47__CollaborationsUpdates.kt
@@ -1,0 +1,14 @@
+package io.newm.server.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("unused")
+class V47__CollaborationsUpdates : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            exec("ALTER TABLE collaborations ADD COLUMN IF NOT EXISTS distribution_participant_id BIGINT")
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/database/CollaborationEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/database/CollaborationEntity.kt
@@ -42,6 +42,7 @@ class CollaborationEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var featured: Boolean by CollaborationTable.featured
     var status: CollaborationStatus by CollaborationTable.status
     var distributionArtistId: Long? by CollaborationTable.distributionArtistId
+    var distributionParticipantId: Long? by CollaborationTable.distributionParticipantId
 
     fun toModel(): Collaboration =
         Collaboration(
@@ -55,6 +56,7 @@ class CollaborationEntity(id: EntityID<UUID>) : UUIDEntity(id) {
             featured = featured,
             status = status,
             distributionArtistId = distributionArtistId,
+            distributionParticipantId = distributionParticipantId
         )
 
     companion object : UUIDEntityClass<CollaborationEntity>(CollaborationTable) {

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/database/CollaborationTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/database/CollaborationTable.kt
@@ -22,4 +22,5 @@ object CollaborationTable : UUIDTable(name = "collaborations") {
     val status: Column<CollaborationStatus> =
         enumeration("status", CollaborationStatus::class).default(CollaborationStatus.Editing)
     val distributionArtistId: Column<Long?> = long("distribution_artist_id").nullable()
+    val distributionParticipantId: Column<Long?> = long("distribution_participant_id").nullable()
 }

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/model/Collaboration.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/model/Collaboration.kt
@@ -24,4 +24,5 @@ data class Collaboration(
     val featured: Boolean? = null,
     val status: CollaborationStatus? = null,
     val distributionArtistId: Long? = null,
+    val distributionParticipantId: Long? = null,
 )

--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/DistributionRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/DistributionRepository.kt
@@ -1,5 +1,6 @@
 package io.newm.server.features.distribution
 
+import io.newm.server.features.collaboration.model.Collaboration
 import io.newm.server.features.distribution.model.AddAlbumResponse
 import io.newm.server.features.distribution.model.AddArtistRequest
 import io.newm.server.features.distribution.model.AddArtistResponse
@@ -87,9 +88,17 @@ interface DistributionRepository {
 
     suspend fun getArtistOutletProfileNames(user: User): GetOutletProfileNamesResponse
 
-    suspend fun addParticipant(user: User): AddParticipantResponse
+    suspend fun addParticipant(
+        user: User,
+        collabUser: User? = null,
+        collab: Collaboration? = null,
+    ): AddParticipantResponse
 
-    suspend fun updateParticipant(user: User): EvearaSimpleResponse
+    suspend fun updateParticipant(
+        user: User,
+        collabUser: User? = null,
+        collab: Collaboration? = null,
+    ): EvearaSimpleResponse
 
     suspend fun getParticipants(user: User): GetParticipantsResponse
 
@@ -129,7 +138,6 @@ interface DistributionRepository {
 
     suspend fun updateAlbum(
         user: User,
-        trackId: Long,
         song: Song
     ): EvearaSimpleResponse
 


### PR DESCRIPTION
In addition to the refactoring, the main logic change is removing the deleteAlbum() call and instead using updateAlbum(). So now, instead of deleting/re-creating the album record, we are trying to just update it.