### PR TITLE
Bypass force_distribute for testing purposes

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/minting/MintingMessageReceiver.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/minting/MintingMessageReceiver.kt
@@ -174,7 +174,7 @@ class MintingMessageReceiver : SqsMessageReceiver {
 
                     quartzSchedulerDaemon.scheduleJob(jobDetail, trigger)
 
-                    if (!cardanoRepository.isMainnet()) {
+                    if (!cardanoRepository.isMainnet() && song.title?.contains("[NoForce]", true) != true) {
                         // If we are on testnet, pretend that the song is already successfully distributed
                         songRepository.update(song.id!!, Song(forceDistributed = true))
                     }


### PR DESCRIPTION
In the test environment, we will want to have some songs not be force distributed so we can manually decline several times and re-distribute several times for testing the unhappy paths.  We cannot use the distribution failure flag because the actual song is still sitting "in review" on the eveara side. This flag on a song removes any pretending on our side so we can test all the actual statuses on the eveara side.