### PR TITLE
Fix: tx builder dummy fees

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
 allprojects {
     group = "io.newm.server"
-    version = "0.2.0-SNAPSHOT"
+    version = "0.2.1-SNAPSHOT"
 }
 
 subprojects {

--- a/newm-tx-builder/src/main/kotlin/io/newm/txbuilder/TransactionBuilder.kt
+++ b/newm-tx-builder/src/main/kotlin/io/newm/txbuilder/TransactionBuilder.kt
@@ -430,7 +430,7 @@ class TransactionBuilder(
                 TX_KEY_UTXO_INPUTS to sourceUtxos!!.toCborObject(),
                 // Utxo outputs
                 TX_KEY_UTXO_OUTPUTS to createOutputUtxos(),
-                TX_KEY_FEE to (fee?.let { CborInteger.create(it) } ?: CborInteger.create(3000000L)),
+                TX_KEY_FEE to (fee?.let { CborInteger.create(it) } ?: CborInteger.create(DUMMY_TX_FEE)),
                 TX_KEY_TTL to ttlAbsoluteSlot?.let { CborInteger.create(it) },
                 // TODO: Implement posting certificates to chain
                 TX_KEY_CERTIFICATES to null,
@@ -492,9 +492,7 @@ class TransactionBuilder(
             }
         }
 
-        if (fee != null) {
-            changeLovelace -= fee!!
-        }
+        changeLovelace -= (fee ?: DUMMY_TX_FEE)
 
         val changeUtxos =
             if (changeLovelace > 0) {
@@ -773,6 +771,7 @@ class TransactionBuilder(
 
         internal const val AUX_DATA_TAG = 259
 
+        private const val DUMMY_TX_FEE = 2000000L // 2 ada
         private const val DUMMY_TOTAL_COLLATERAL = 4000000L // 4 ada
     }
 }


### PR DESCRIPTION
dummy collateral is 4 ada. Dummy fee was 3 ada. Total collateral is supposed to be fee * 1.5 which was 4.5 ada. Now setting the dummy fee to 2 ada, we're good to go.