### PR TITLE
bump version and deploy to maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
 allprojects {
     group = "io.newm.server"
-    version = "0.2.1-SNAPSHOT"
+    version = "0.2.2-SNAPSHOT"
 }
 
 subprojects {


### PR DESCRIPTION
I needed to bump the version and deploy newm-tx-builder and other libs to maven since I had previously updated the underlying cbor library to fix a bug.