### PR TITLE
STUD-220: Add some backend album support

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -97,7 +97,7 @@ object Dependencies {
     }
 
     object Koin {
-        private const val VERSION = "3.5.4"
+        private const val VERSION = "3.5.6"
 
         const val KTOR = "io.insert-koin:koin-ktor:$VERSION"
         const val TEST = "io.insert-koin:koin-test:$VERSION"
@@ -132,7 +132,7 @@ object Dependencies {
     }
 
     object FlywayDB {
-        private const val VERSION = "10.11.0"
+        private const val VERSION = "10.11.1"
 
         const val CORE = "org.flywaydb:flyway-core:$VERSION"
         const val POSTGRES = "org.flywaydb:flyway-database-postgresql:$VERSION"
@@ -201,7 +201,7 @@ object Dependencies {
     }
 
     object SpringSecurity {
-        private const val VERSION = "6.2.3"
+        private const val VERSION = "6.2.4"
 
         const val CORE = "org.springframework.security:spring-security-core:$VERSION"
     }
@@ -214,8 +214,8 @@ object Dependencies {
     }
 
     object Aws {
-        private const val VERSION = "1.12.697"
-        private const val VERSION2 = "2.25.27"
+        private const val VERSION = "1.12.709"
+        private const val VERSION2 = "2.25.39"
         private const val JAXB_VERSION = "2.3.1"
 
         const val BOM = "com.amazonaws:aws-java-sdk-bom:$VERSION"

--- a/newm-server/src/main/kotlin/io/newm/server/aws/AwsKoinModule.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/aws/AwsKoinModule.kt
@@ -1,5 +1,7 @@
 package io.newm.server.aws
 
+import com.amazonaws.regions.Region
+import com.amazonaws.regions.RegionUtils
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.kms.AWSKMSAsync
 import com.amazonaws.services.kms.AWSKMSAsyncClientBuilder
@@ -48,5 +50,5 @@ val awsKoinModule =
                 .build()
         }
 
-        single { Regions.fromName(get<ApplicationEnvironment>().getConfigString("aws.region")) }
+        single<Region> { RegionUtils.getRegion(get<ApplicationEnvironment>().getConfigString("aws.region")) }
     }

--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V53__CreateReleases.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V53__CreateReleases.kt
@@ -1,0 +1,90 @@
+package io.newm.server.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class V53__CreateReleases : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            execInBatch(
+                listOf(
+                    """
+                    CREATE TABLE IF NOT EXISTS releases
+                    (
+                        id uuid PRIMARY KEY,
+                        owner_id uuid NOT NULL,
+                        release_type varchar(20) NOT NULL,
+                        title text NOT NULL,
+                        distribution_release_id bigint,
+                        barcode_type integer,
+                        barcode_number text,
+                        release_date DATE,
+                        publication_date DATE,
+                        cover_art_url text,
+                        arweave_cover_art_url text,
+                        has_submitted_for_distribution boolean NOT NULL DEFAULT FALSE,
+                        error_message text,
+                        force_distributed boolean NOT NULL DEFAULT FALSE,
+                        archived boolean NOT NULL DEFAULT FALSE,
+                        created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT fk_releases_owner_id__id FOREIGN KEY (owner_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION
+                    )
+                    """.trimIndent(),
+                    """
+                    ALTER TABLE songs
+                    RENAME COLUMN album TO release_id;
+                    """.trimIndent(),
+                    """
+                    ALTER TABLE songs
+                    ALTER COLUMN release_id SET DATA TYPE uuid USING release_id::uuid;
+                    """.trimIndent(),
+                    """
+                    ALTER TABLE songs
+                    ADD CONSTRAINT IF NOT EXISTS fk_songs_release_id__id FOREIGN KEY (release_id) REFERENCES releases (id) ON ON UPDATE NO ACTION ON DELETE NO ACTION;
+                    """.trimIndent(),
+                    // Note: initially, a release_id will match a song_id since everything is a single and it makes this
+                    // migration simpler. In the future, that will not be the case.
+                    """
+                    INSERT INTO releases (id, owner_id, release_type, title, distribution_release_id, barcode_type, barcode_number, release_date, publication_date, cover_art_url, arweave_cover_art_url, has_submitted_for_distribution, error_message, force_distributed, archived, created_at)
+                    (SELECT
+                        id,
+                        owner_id,
+                        'single',
+                        title,
+                        distribution_release_id,
+                        barcode_type,
+                        barcode_number,
+                        release_date,
+                        publication_date,
+                        cover_art_url,
+                        arweave_cover_art_url,
+                        has_submitted_for_distribution,
+                        error_message,
+                        force_distributed,
+                        archived,
+                        created_at
+                    FROM songs);
+                    """.trimIndent(),
+                    """
+                    UPDATE songs
+                    SET release_id = id;
+                    """.trimIndent(),
+                    """
+                    ALTER TABLE songs
+                    DROP COLUMN distribution_release_id,
+                    DROP COLUMN barcode_type,
+                    DROP COLUMN barcode_number,
+                    DROP COLUMN release_date,
+                    DROP COLUMN publication_date,
+                    DROP COLUMN cover_art_url,
+                    DROP COLUMN arweave_cover_art_url,
+                    DROP COLUMN has_submitted_for_distribution
+                    DROP COLUMN force_distributed,
+                    DROP COLUMN error_message;
+                    """.trimIndent()
+                )
+            )
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/arweave/ktx/SongExt.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/arweave/ktx/SongExt.kt
@@ -1,20 +1,21 @@
 package io.newm.server.features.arweave.ktx
 
+import io.newm.server.features.song.model.Release
 import io.newm.server.features.song.model.Song
 import io.newm.server.ktx.asValidUrl
-import io.newm.shared.ktx.info
-import org.slf4j.Logger
 import io.newm.shared.koin.inject
+import io.newm.shared.ktx.info
 import org.koin.core.parameter.parametersOf
+import org.slf4j.Logger
 
 private val IMAGE_WEBP_REPLACE_REGEX = Regex("\\.(png|jpg|jpeg|bmp|gif|tiff)\$", RegexOption.IGNORE_CASE)
 
-fun Song.toFiles(): List<Pair<String, String>> {
+fun Song.toFiles(release: Release): List<Pair<String, String>> {
     val log: Logger by inject { parametersOf(javaClass.simpleName) }
 
     return listOfNotNull(
-        if (arweaveCoverArtUrl != null) {
-            log.info { "Song $id already has arweave cover art url: $arweaveCoverArtUrl" }
+        if (release.arweaveCoverArtUrl != null) {
+            log.info { "Release ${release.id} already has arweave cover art url: $release.arweaveCoverArtUrl" }
             null
         } else {
             coverArtUrl.asValidUrl().replace(IMAGE_WEBP_REPLACE_REGEX, ".webp") to "image/webp"

--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/DistributionRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/DistributionRepository.kt
@@ -1,43 +1,13 @@
 package io.newm.server.features.distribution
 
 import io.newm.server.features.collaboration.model.Collaboration
-import io.newm.server.features.distribution.model.AddAlbumResponse
-import io.newm.server.features.distribution.model.AddArtistRequest
-import io.newm.server.features.distribution.model.AddArtistResponse
-import io.newm.server.features.distribution.model.AddParticipantResponse
-import io.newm.server.features.distribution.model.AddTrackResponse
-import io.newm.server.features.distribution.model.AddUserLabelResponse
-import io.newm.server.features.distribution.model.AddUserResponse
-import io.newm.server.features.distribution.model.AddUserSubscriptionResponse
-import io.newm.server.features.distribution.model.DeleteUserLabelResponse
-import io.newm.server.features.distribution.model.DistributeReleaseResponse
-import io.newm.server.features.distribution.model.DistributionOutletReleaseStatusResponse
-import io.newm.server.features.distribution.model.EvearaSimpleResponse
-import io.newm.server.features.distribution.model.GetAlbumResponse
-import io.newm.server.features.distribution.model.GetArtistResponse
-import io.newm.server.features.distribution.model.GetCountriesResponse
-import io.newm.server.features.distribution.model.GetGenresResponse
-import io.newm.server.features.distribution.model.GetLanguagesResponse
-import io.newm.server.features.distribution.model.GetOutletProfileNamesResponse
-import io.newm.server.features.distribution.model.GetOutletsResponse
-import io.newm.server.features.distribution.model.GetParticipantsResponse
-import io.newm.server.features.distribution.model.GetPayoutBalanceResponse
-import io.newm.server.features.distribution.model.GetPayoutHistoryResponse
-import io.newm.server.features.distribution.model.GetRolesResponse
-import io.newm.server.features.distribution.model.GetTracksResponse
-import io.newm.server.features.distribution.model.GetUserLabelResponse
-import io.newm.server.features.distribution.model.GetUserResponse
-import io.newm.server.features.distribution.model.GetUserSubscriptionResponse
-import io.newm.server.features.distribution.model.InitiatePayoutResponse
-import io.newm.server.features.distribution.model.UpdateArtistRequest
-import io.newm.server.features.distribution.model.UpdateArtistResponse
-import io.newm.server.features.distribution.model.UpdateUserLabelResponse
-import io.newm.server.features.distribution.model.ValidateAlbumResponse
+import io.newm.server.features.distribution.model.*
+import io.newm.server.features.song.model.Release
 import io.newm.server.features.song.model.Song
 import io.newm.server.features.user.model.User
 import java.io.File
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 /**
  * Higher level api for working with a music distribution service
@@ -133,15 +103,16 @@ interface DistributionRepository {
 
     suspend fun addAlbum(
         user: User,
-        trackId: Long,
-        song: Song
+        release: Release,
+        songs: List<Song>
     ): AddAlbumResponse
 
     suspend fun getAlbums(user: User): GetAlbumResponse
 
     suspend fun updateAlbum(
         user: User,
-        song: Song
+        release: Release,
+        songs: List<Song>
     ): EvearaSimpleResponse
 
     suspend fun validateAlbum(
@@ -161,7 +132,7 @@ interface DistributionRepository {
 
     suspend fun distributeReleaseToOutlets(
         user: User,
-        song: Song,
+        release: Release,
         allowRetry: Boolean = true,
     ): DistributeReleaseResponse
 
@@ -175,9 +146,9 @@ interface DistributionRepository {
         releaseId: Long
     ): DistributionOutletReleaseStatusResponse
 
-    suspend fun distributeSong(song: Song)
+    suspend fun distributeRelease(release: Release)
 
-    suspend fun redistributeSong(song: Song)
+    suspend fun redistributeRelease(release: Release)
 
     suspend fun getEarliestReleaseDate(userId: UUID): LocalDate
 

--- a/newm-server/src/main/kotlin/io/newm/server/features/marketplace/database/MarketplaceSaleEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/marketplace/database/MarketplaceSaleEntity.kt
@@ -5,6 +5,7 @@ import io.newm.server.features.marketplace.model.Sale
 import io.newm.server.features.marketplace.model.SaleFilters
 import io.newm.server.features.marketplace.model.SaleStatus
 import io.newm.server.features.marketplace.model.Token
+import io.newm.server.features.song.database.ReleaseEntity
 import io.newm.server.features.song.database.SongEntity
 import io.newm.server.features.song.database.SongTable
 import io.newm.server.features.user.database.UserEntity
@@ -63,6 +64,7 @@ class MarketplaceSaleEntity(id: EntityID<UUID>) : UUIDEntity(id) {
             availableBundleQuantity = availableBundleQuantity,
             song =
                 SongEntity[songId].run {
+                    val release = ReleaseEntity[releaseId!!]
                     Sale.Song(
                         id = id.value,
                         artistId = ownerId.value,
@@ -70,7 +72,7 @@ class MarketplaceSaleEntity(id: EntityID<UUID>) : UUIDEntity(id) {
                         title = title,
                         genres = genres.toList(),
                         moods = moods?.toList(),
-                        coverArtUrl = coverArtUrl,
+                        coverArtUrl = release.coverArtUrl,
                         clipUrl = clipUrl,
                         tokenAgreementUrl = tokenAgreementUrl,
                         collaborators =

--- a/newm-server/src/main/kotlin/io/newm/server/features/playlist/repo/PlaylistRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/playlist/repo/PlaylistRepositoryImpl.kt
@@ -1,17 +1,17 @@
 package io.newm.server.features.playlist.repo
 
-import io.newm.server.ktx.checkLength
 import io.ktor.util.logging.*
-import io.newm.shared.exception.HttpForbiddenException
-import io.newm.shared.exception.HttpUnprocessableEntityException
 import io.newm.server.features.playlist.database.PlaylistEntity
 import io.newm.server.features.playlist.model.Playlist
 import io.newm.server.features.playlist.model.PlaylistFilters
-import io.newm.server.features.song.database.SongEntity
+import io.newm.server.features.song.database.ReleaseEntity
 import io.newm.server.features.song.model.Song
 import io.newm.server.features.user.database.UserTable
-import io.newm.shared.ktx.debug
+import io.newm.server.ktx.checkLength
+import io.newm.shared.exception.HttpForbiddenException
+import io.newm.shared.exception.HttpUnprocessableEntityException
 import io.newm.shared.koin.inject
+import io.newm.shared.ktx.debug
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.koin.core.parameter.parametersOf
@@ -121,7 +121,10 @@ internal class PlaylistRepositoryImpl : PlaylistRepository {
     ): List<Song> {
         logger.debug { "getSongs: playlistId = $playlistId, offset = $offset, limit = $limit" }
         return transaction {
-            PlaylistEntity[playlistId].songs.limit(n = limit, offset = offset.toLong()).map(SongEntity::toModel)
+            PlaylistEntity[playlistId].songs.limit(n = limit, offset = offset.toLong()).map { songEntity ->
+                val release = ReleaseEntity[songEntity.releaseId!!].toModel()
+                songEntity.toModel(release)
+            }
         }
     }
 

--- a/newm-server/src/main/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJob.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJob.kt
@@ -45,8 +45,9 @@ class EvearaReleaseStatusJob : Job {
             try {
                 val user = userRepository.get(userId)
                 val song = songRepository.get(songId)
+                val release = songRepository.getRelease(song.releaseId!!)
                 val distributionReleaseStatusResponse =
-                    distributionRepository.distributionOutletReleaseStatus(user, song.distributionReleaseId!!)
+                    distributionRepository.distributionOutletReleaseStatus(user, release.distributionReleaseId!!)
                 val spotifyOutletStatusCode =
                     if (song.forceDistributed == true) {
                         // If the song is force distributed, then we can mark it as disapproved or distributed
@@ -88,7 +89,7 @@ class EvearaReleaseStatusJob : Job {
                                 "Failed to get album disapproveMessage: ${albumsResponse.message}"
                             )
                         } else {
-                            albumsResponse.albumData.firstOrNull { it.releaseId == song.distributionReleaseId }?.let {
+                            albumsResponse.albumData.firstOrNull { it.releaseId == release.distributionReleaseId }?.let {
                                 songRepository.updateSongMintingStatus(
                                     songId,
                                     MintingStatus.Declined,
@@ -115,7 +116,7 @@ class EvearaReleaseStatusJob : Job {
                             // We're on testnet, so we can simulate distribution
                             log.info { "Simulating distribution for $songId on testnet" }
                             val response =
-                                distributionRepository.simulateDistributeRelease(user, song.distributionReleaseId)
+                                distributionRepository.simulateDistributeRelease(user, release.distributionReleaseId)
                             log.info { "Simulated distribution response: $response" }
                         }
                         log.info {

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/SongRoutes.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/SongRoutes.kt
@@ -9,12 +9,7 @@ import io.ktor.server.routing.route
 import io.newm.server.auth.jwt.AUTH_JWT
 import io.newm.server.auth.jwt.AUTH_JWT_ADMIN
 import io.newm.server.features.model.CountResponse
-import io.newm.server.features.song.model.AudioStreamResponse
-import io.newm.server.features.song.model.MintPaymentRequest
-import io.newm.server.features.song.model.MintPaymentResponse
-import io.newm.server.features.song.model.SongIdBody
-import io.newm.server.features.song.model.StreamTokenAgreementRequest
-import io.newm.server.features.song.model.songFilters
+import io.newm.server.features.song.model.*
 import io.newm.server.features.song.repo.SongRepository
 import io.newm.server.features.user.model.User
 import io.newm.server.features.user.repo.UserRepository
@@ -86,7 +81,8 @@ fun Routing.createSongRoutes() {
                     respond(songRepository.get(songId))
                 }
                 patch {
-                    songRepository.update(songId, receive(), myUserId)
+                    val song: Song = receive()
+                    songRepository.update(songId, song, myUserId)
                     respond(HttpStatusCode.NoContent)
                 }
                 delete {

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseEntity.kt
@@ -1,0 +1,116 @@
+package io.newm.server.features.song.database
+
+import io.newm.server.features.song.model.Release
+import io.newm.server.features.song.model.ReleaseBarcodeType
+import io.newm.server.features.song.model.ReleaseType
+import io.newm.server.features.song.model.SongFilters
+import io.newm.server.features.user.database.UserTable
+import io.newm.shared.ktx.exists
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+class ReleaseEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    var archived: Boolean by ReleaseTable.archived
+    val createdAt: LocalDateTime by ReleaseTable.createdAt
+    var ownerId: EntityID<UUID> by ReleaseTable.ownerId
+    var title: String by ReleaseTable.title
+    var releaseType: ReleaseType by ReleaseTable.releaseType
+    var distributionReleaseId: Long? by ReleaseTable.distributionReleaseId
+    var barcodeType: ReleaseBarcodeType? by ReleaseTable.barcodeType
+    var barcodeNumber: String? by ReleaseTable.barcodeNumber
+    var releaseDate: LocalDate? by ReleaseTable.releaseDate
+    var publicationDate: LocalDate? by ReleaseTable.publicationDate
+    var coverArtUrl: String? by ReleaseTable.coverArtUrl
+    var arweaveCoverArtUrl: String? by ReleaseTable.arweaveCoverArtUrl
+    var hasSubmittedForDistribution: Boolean by ReleaseTable.hasSubmittedForDistribution
+    var errorMessage: String? by ReleaseTable.errorMessage
+    var forceDistributed: Boolean by ReleaseTable.forceDistributed
+
+    fun toModel(): Release =
+        Release(
+            id = id.value,
+            archived = archived,
+            ownerId = ownerId.value,
+            createdAt = createdAt,
+            title = title,
+            releaseType = releaseType,
+            distributionReleaseId = distributionReleaseId,
+            coverArtUrl = coverArtUrl,
+            arweaveCoverArtUrl = arweaveCoverArtUrl,
+            barcodeType = barcodeType,
+            barcodeNumber = barcodeNumber,
+            releaseDate = releaseDate,
+            publicationDate = publicationDate,
+            hasSubmittedForDistribution = hasSubmittedForDistribution,
+            errorMessage = errorMessage,
+        )
+
+    companion object : UUIDEntityClass<ReleaseEntity>(ReleaseTable) {
+        fun all(filters: SongFilters): SizedIterable<ReleaseEntity> {
+            val ops = filters.toOps()
+            return when {
+                ops.isEmpty() -> all()
+                filters.phrase == null -> find(AndOp(ops))
+                else ->
+                    ReleaseEntity.wrapRows(
+                        ReleaseTable.innerJoin(
+                            otherTable = UserTable,
+                            onColumn = { ownerId },
+                            otherColumn = { id }
+                        ).selectAll().where(AndOp(ops))
+                    )
+            }.orderBy(ReleaseTable.createdAt to (filters.sortOrder ?: SortOrder.ASC))
+        }
+
+        fun exists(
+            ownerId: UUID,
+            title: String
+        ): Boolean =
+            exists {
+                (ReleaseTable.archived eq false) and
+                    (ReleaseTable.ownerId eq ownerId) and
+                    (ReleaseTable.title.lowerCase() eq title.lowercase())
+            }
+
+        private fun SongFilters.toOps(): List<Op<Boolean>> {
+            val ops = mutableListOf<Op<Boolean>>()
+            ops += ReleaseTable.archived eq (archived ?: false)
+            olderThan?.let {
+                ops += ReleaseTable.createdAt less it
+            }
+            newerThan?.let {
+                ops += ReleaseTable.createdAt greater it
+            }
+            ids?.let {
+                ops += ReleaseTable.id inList it
+            }
+            ownerIds?.let {
+                ops += ReleaseTable.ownerId inList it
+            }
+            phrase?.let {
+                val pattern = "%${it.lowercase()}%"
+                ops += (
+                    (ReleaseTable.title.lowerCase() like pattern)
+                        or (UserTable.nickname.lowerCase() like pattern)
+                        or (
+                            (UserTable.nickname eq null) and (
+                                (UserTable.firstName.lowerCase() like pattern)
+                                    or (UserTable.lastName.lowerCase() like pattern)
+                            )
+                        )
+                )
+            }
+            return ops
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseTable.kt
@@ -1,0 +1,33 @@
+package io.newm.server.features.song.database
+
+import io.newm.server.features.song.model.ReleaseType
+import io.newm.server.features.song.model.ReleaseBarcodeType
+import io.newm.server.features.user.database.UserTable
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
+import org.jetbrains.exposed.sql.javatime.date
+import org.jetbrains.exposed.sql.javatime.datetime
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+object ReleaseTable : UUIDTable(name = "releases") {
+    val archived: Column<Boolean> = bool("archived").default(false)
+    val createdAt: Column<LocalDateTime> = datetime("created_at").defaultExpression(CurrentDateTime)
+    val ownerId: Column<EntityID<UUID>> = reference("owner_id", UserTable, onDelete = ReferenceOption.NO_ACTION)
+    val title: Column<String> = text("title")
+    val releaseType: Column<ReleaseType> = enumerationByName("release_type", 20, ReleaseType::class)
+    val distributionReleaseId: Column<Long?> = long("distribution_release_id").nullable()
+    val barcodeType: Column<ReleaseBarcodeType?> = enumeration("barcode_type", ReleaseBarcodeType::class).nullable()
+    val barcodeNumber: Column<String?> = text("barcode_number").nullable()
+    val releaseDate: Column<LocalDate?> = date("release_date").nullable()
+    val publicationDate: Column<LocalDate?> = date("publication_date").nullable()
+    val coverArtUrl: Column<String?> = text("cover_art_url").nullable()
+    val arweaveCoverArtUrl: Column<String?> = text("arweave_cover_art_url").nullable()
+    val hasSubmittedForDistribution: Column<Boolean> = bool("has_submitted_for_distribution").default(false)
+    val errorMessage: Column<String?> = text("error_message").nullable()
+    val forceDistributed: Column<Boolean> = bool("force_distributed").default(false)
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/database/SongTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/database/SongTable.kt
@@ -4,7 +4,6 @@ import io.newm.server.features.cardano.database.KeyTable
 import io.newm.server.features.song.model.AudioEncodingStatus
 import io.newm.server.features.song.model.MarketplaceStatus
 import io.newm.server.features.song.model.MintingStatus
-import io.newm.server.features.song.model.SongBarcodeType
 import io.newm.server.features.user.database.UserTable
 import io.newm.shared.exposed.textArray
 import org.jetbrains.exposed.dao.id.EntityID
@@ -12,9 +11,7 @@ import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.javatime.CurrentDateTime
-import org.jetbrains.exposed.sql.javatime.date
 import org.jetbrains.exposed.sql.javatime.datetime
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -25,9 +22,8 @@ object SongTable : UUIDTable(name = "songs") {
     val title: Column<String> = text("title")
     val genres: Column<Array<String>> = textArray("genres")
     val moods: Column<Array<String>?> = textArray("moods").nullable()
-    val coverArtUrl: Column<String?> = text("cover_art_url").nullable()
     val description: Column<String?> = text("description").nullable()
-    val album: Column<String?> = text("album").nullable()
+    val releaseId: Column<EntityID<UUID>?> = reference("release_id", ReleaseTable, onDelete = ReferenceOption.NO_ACTION).nullable()
     val track: Column<Int?> = integer("track").nullable()
     val language: Column<String?> = text("language").nullable()
     val coverRemixSample: Column<Boolean> = bool("cover_remix_sample").default(false)
@@ -36,13 +32,9 @@ object SongTable : UUIDTable(name = "songs") {
     val phonographicCopyrightOwner: Column<String?> = text("phono_copyright_owner").nullable()
     val phonographicCopyrightYear: Column<Int?> = integer("phono_copyright_year").nullable()
     val parentalAdvisory: Column<String?> = text("parental_advisory").nullable()
-    val barcodeType: Column<SongBarcodeType?> = enumeration("barcode_type", SongBarcodeType::class).nullable()
-    val barcodeNumber: Column<String?> = text("barcode_number").nullable()
     val isrc: Column<String?> = text("isrc").nullable()
     val iswc: Column<String?> = text("iswc").nullable()
     val ipis: Column<Array<String>?> = textArray("ipis").nullable()
-    val releaseDate: Column<LocalDate?> = date("release_date").nullable()
-    val publicationDate: Column<LocalDate?> = date("publication_date").nullable()
     val lyricsUrl: Column<String?> = text("lyrics_url").nullable()
     val tokenAgreementUrl: Column<String?> = text("token_agreement_url").nullable()
     val originalAudioUrl: Column<String?> = text("original_audio_url").nullable()
@@ -60,15 +52,10 @@ object SongTable : UUIDTable(name = "songs") {
         enumeration("marketplace_status", MarketplaceStatus::class).default(MarketplaceStatus.NotSelling)
     val paymentKeyId: Column<EntityID<UUID>?> =
         reference("payment_key_id", KeyTable, onDelete = ReferenceOption.NO_ACTION).nullable()
-    val arweaveCoverArtUrl: Column<String?> = text("arweave_cover_art_url").nullable()
     val arweaveLyricsUrl: Column<String?> = text("arweave_lyrics_url").nullable()
     val arweaveTokenAgreementUrl: Column<String?> = text("arweave_token_agreement_url").nullable()
     val arweaveClipUrl: Column<String?> = text("arweave_clip_url").nullable()
     val distributionTrackId: Column<Long?> = long("distribution_track_id").nullable()
-    val distributionReleaseId: Column<Long?> = long("distribution_release_id").nullable()
     val mintCostLovelace: Column<Long?> = long("mint_cost_lovelace").nullable()
-    val forceDistributed: Column<Boolean?> = bool("force_distributed").nullable()
-    val errorMessage: Column<String?> = text("error_message").nullable()
     val instrumental: Column<Boolean> = bool("instrumental").default(false)
-    val hasSubmittedForDistribution: Column<Boolean> = bool("has_submitted_for_distribution").default(false)
 }

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/model/Release.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/model/Release.kt
@@ -1,0 +1,48 @@
+package io.newm.server.features.song.model
+
+import io.newm.shared.serialization.LocalDateSerializer
+import io.newm.shared.serialization.LocalDateTimeSerializer
+import io.newm.shared.serialization.UUIDSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@Serializable
+data class Release(
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID? = null,
+    val archived: Boolean? = null,
+    @Serializable(with = UUIDSerializer::class)
+    val ownerId: UUID? = null,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val createdAt: LocalDateTime? = null,
+    val title: String? = null,
+    val releaseType: ReleaseType? = null,
+    val coverArtUrl: String? = null,
+    val barcodeType: ReleaseBarcodeType? = null,
+    val barcodeNumber: String? = null,
+    @Serializable(with = LocalDateSerializer::class)
+    val releaseDate: LocalDate? = null,
+    @Serializable(with = LocalDateSerializer::class)
+    val publicationDate: LocalDate? = null,
+    @Transient
+    val arweaveCoverArtUrl: String? = null,
+    @Transient
+    val distributionReleaseId: Long? = null,
+    val hasSubmittedForDistribution: Boolean? = null,
+    @Transient
+    val forceDistributed: Boolean? = null,
+    val errorMessage: String? = null,
+) {
+    @Transient
+    val releaseProductCodeType: String =
+        if (barcodeNumber == null || barcodeType == ReleaseBarcodeType.Ean) {
+            "ean"
+        } else if (barcodeType == ReleaseBarcodeType.Upc) {
+            "upc"
+        } else {
+            "jan"
+        }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/model/ReleaseBarcodeType.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/model/ReleaseBarcodeType.kt
@@ -1,18 +1,18 @@
 package io.newm.server.features.song.model
 
-enum class SongBarcodeType {
+enum class ReleaseBarcodeType {
     Upc, // Universal Product Codes (UPC) - 0
     Ean, // International Article Number (EAN) - 1
     Jan, // Japanese Article Number (JAN) - 2
 }
 
-fun String.toSongBarcodeType(): SongBarcodeType {
+fun String.toSongBarcodeType(): ReleaseBarcodeType {
     return if (this.equals("upc", ignoreCase = true)) {
-        SongBarcodeType.Upc
+        ReleaseBarcodeType.Upc
     } else if (this.equals("ean", ignoreCase = true)) {
-        SongBarcodeType.Ean
+        ReleaseBarcodeType.Ean
     } else if (this.equals("jan", ignoreCase = true)) {
-        SongBarcodeType.Jan
+        ReleaseBarcodeType.Jan
     } else {
         throw IllegalArgumentException("Invalid barcode type: $this")
     }

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/model/ReleaseType.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/model/ReleaseType.kt
@@ -1,0 +1,25 @@
+package io.newm.server.features.song.model
+
+enum class ReleaseType(val value: String) {
+    /**
+     * The default release type if it doesn't fall into any other category.
+     */
+    ALBUM("album"),
+
+    /**
+     * Only one track is allowed.
+     */
+    SINGLE("single"),
+
+    /**
+     * The release should have more than four main artists.
+     */
+    COMPILATION_ALBUM("compilation_album"),
+
+    /**
+     * Combined tracks duration cannot exceed 30 minutes.
+     * Can add only up to six tracks.
+     * If number of tracks are three or less, at least one track should be 10 minutes long.
+     */
+    EP("ep"),
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/model/Song.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/model/Song.kt
@@ -21,9 +21,11 @@ data class Song(
     val title: String? = null,
     val genres: List<String>? = null,
     val moods: List<String>? = null,
+    // FIXME: Keep coverArtUrl for now since the UI/UX expects it. Eventually this will only be on the Release instead of the Song.
     val coverArtUrl: String? = null,
     val description: String? = null,
-    val album: String? = null,
+    @Serializable(with = UUIDSerializer::class)
+    val releaseId: UUID? = null,
     val track: Int? = null,
     val language: String? = null,
     val coverRemixSample: Boolean? = null,
@@ -32,13 +34,17 @@ data class Song(
     val phonographicCopyrightOwner: String? = null,
     val phonographicCopyrightYear: Int? = null,
     val parentalAdvisory: String? = null,
-    val barcodeType: SongBarcodeType? = null,
+    // FIXME: Keep barcodeType for now since the UI/UX expects it. Eventually this will only be on the Release instead of the Song.
+    val barcodeType: ReleaseBarcodeType? = null,
+    // FIXME: Keep barcodeNumber for now since the UI/UX expects it. Eventually this will only be on the Release instead of the Song.
     val barcodeNumber: String? = null,
     val isrc: String? = null,
     val iswc: String? = null,
     val ipis: List<String>? = null,
+    // FIXME: Keep releaseDate for now since the UI/UX expects it. Eventually this will only be on the Release instead of the Song.
     @Serializable(with = LocalDateSerializer::class)
     val releaseDate: LocalDate? = null,
+    // FIXME: Keep publicationDate for now since the UI/UX expects it. Eventually this will only be on the Release instead of the Song.
     @Serializable(with = LocalDateSerializer::class)
     val publicationDate: LocalDate? = null,
     val lyricsUrl: String? = null,
@@ -56,8 +62,6 @@ data class Song(
     @Serializable(with = UUIDSerializer::class)
     val paymentKeyId: UUID? = null,
     @Transient
-    val arweaveCoverArtUrl: String? = null,
-    @Transient
     val arweaveLyricsUrl: String? = null,
     @Transient
     val arweaveTokenAgreementUrl: String? = null,
@@ -66,12 +70,10 @@ data class Song(
     @Transient
     val distributionTrackId: Long? = null,
     @Transient
-    val distributionReleaseId: Long? = null,
-    @Transient
     val mintCostLovelace: Long? = null,
     @Transient
     val forceDistributed: Boolean? = null,
+    // FIXME: Keep errorMessage for now since the UI/UX expects it. Eventually this will only be on the Release instead of the Song.
     val errorMessage: String? = null,
     val instrumental: Boolean? = null,
-    val hasSubmittedForDistribution: Boolean? = null,
 )

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepository.kt
@@ -1,16 +1,10 @@
 package io.newm.server.features.song.repo
 
-import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.*
 import io.newm.chain.grpc.Utxo
 import io.newm.server.features.song.database.SongEntity
-import io.newm.server.features.song.model.AudioStreamData
-import io.newm.server.features.song.model.AudioUploadReport
-import io.newm.server.features.song.model.MintPaymentResponse
-import io.newm.server.features.song.model.MintingStatus
-import io.newm.server.features.song.model.RefundPaymentResponse
-import io.newm.server.features.song.model.Song
-import io.newm.server.features.song.model.SongFilters
-import java.util.UUID
+import io.newm.server.features.song.model.*
+import java.util.*
 
 interface SongRepository {
     suspend fun add(
@@ -24,12 +18,20 @@ interface SongRepository {
         requesterId: UUID? = null
     )
 
+    suspend fun update(
+        releaseId: UUID,
+        release: Release,
+        requesterId: UUID? = null
+    )
+
     suspend fun delete(
         songId: UUID,
         requesterId: UUID
     )
 
     suspend fun get(songId: UUID): Song
+
+    suspend fun getRelease(releaseId: UUID): Release
 
     suspend fun getAll(
         filters: SongFilters,
@@ -38,6 +40,8 @@ interface SongRepository {
     ): List<Song>
 
     suspend fun getAllCount(filters: SongFilters): Long
+
+    suspend fun getAllByReleaseId(id: UUID): List<Song>
 
     suspend fun getGenres(
         filters: SongFilters,

--- a/newm-server/src/test/kotlin/io/newm/server/features/arweave/ktx/SongExtTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/arweave/ktx/SongExtTest.kt
@@ -1,6 +1,7 @@
 package io.newm.server.features.arweave.ktx
 import com.google.common.truth.Truth.assertThat
 import io.newm.server.features.song.model.MintingStatus
+import io.newm.server.features.song.model.Release
 import io.newm.server.features.song.model.Song
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterAll
@@ -13,7 +14,7 @@ import org.koin.test.KoinTest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 class SongExtTest : KoinTest {
     companion object {
@@ -42,20 +43,27 @@ class SongExtTest : KoinTest {
     @Test
     fun `test should return empty list`() =
         runTest {
+            val ownerId = UUID.randomUUID()
+            val release =
+                Release(
+                    ownerId = ownerId,
+                    title = "Daisuke",
+                    releaseDate = LocalDate.parse("2023-02-03"),
+                    publicationDate = LocalDate.parse("2023-02-03"),
+                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
+                )
             val song =
                 Song(
-                    ownerId = UUID.randomUUID(),
+                    ownerId = ownerId,
                     title = "Daisuke",
                     genres = listOf("Pop", "House", "Tribal"),
                     releaseDate = LocalDate.parse("2023-02-03"),
                     publicationDate = LocalDate.parse("2023-02-03"),
                     isrc = "QZ-NW7-23-57511",
                     moods = listOf("spiritual"),
-                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
                     arweaveLyricsUrl = "ar://7vQTHTkgybn8nVLDlukGiBazy2NZVhWP6HZdJdmPH00",
                     arweaveTokenAgreementUrl = "ar://eK8gAPCvJ-9kbiP3PrSMwLGAk38aNyxPDudzzbGypxE",
                     arweaveClipUrl = "ar://QpgjmWmAHNeRVgx_Ylwvh16i3aWd8BBgyq7f16gaUu0",
-                    album = "Daisuke",
                     duration = 200000,
                     track = 1,
                     compositionCopyrightOwner = "Mirai Music Publishing",
@@ -65,27 +73,34 @@ class SongExtTest : KoinTest {
                     mintingStatus = MintingStatus.Pending
                 )
 
-            val actual: List<Pair<String, String>> = song.toFiles()
+            val actual: List<Pair<String, String>> = song.toFiles(release)
             assertThat(actual).isEqualTo(listOfNotNull(null))
         }
 
     @Test
     fun `test should return non empty list`() =
         runTest {
+            val ownerId = UUID.randomUUID()
+            val release =
+                Release(
+                    ownerId = ownerId,
+                    title = "Daisuke",
+                    releaseDate = LocalDate.parse("2023-02-03"),
+                    publicationDate = LocalDate.parse("2023-02-03"),
+                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
+                )
             val song =
                 Song(
-                    ownerId = UUID.randomUUID(),
+                    ownerId = ownerId,
                     title = "Daisuke",
                     genres = listOf("Pop", "House", "Tribal"),
                     releaseDate = LocalDate.parse("2023-02-03"),
                     publicationDate = LocalDate.parse("2023-02-03"),
                     isrc = "QZ-NW7-23-57511",
                     moods = listOf("spiritual"),
-                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
                     arweaveLyricsUrl = "ar://7vQTHTkgybn8nVLDlukGiBazy2NZVhWP6HZdJdmPH00",
                     arweaveClipUrl = "ar://QpgjmWmAHNeRVgx_Ylwvh16i3aWd8BBgyq7f16gaUu0",
                     tokenAgreementUrl = "https://newm.io/agreement",
-                    album = "Daisuke",
                     duration = 200000,
                     track = 1,
                     compositionCopyrightOwner = "Mirai Music Publishing",
@@ -95,7 +110,7 @@ class SongExtTest : KoinTest {
                     mintingStatus = MintingStatus.Pending
                 )
 
-            val actual = song.toFiles()
+            val actual = song.toFiles(release)
             assertThat(actual).isEqualTo(listOf(Pair("https://newm.io/agreement", "application/pdf")))
         }
 }

--- a/newm-server/src/test/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryTest.kt
@@ -3,7 +3,7 @@ package io.newm.server.features.distribution.eveara
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import com.google.common.truth.Truth.assertThat
-import io.ktor.server.application.ApplicationEnvironment
+import io.ktor.server.application.*
 import io.mockk.mockk
 import io.newm.server.BaseApplicationTests
 import io.newm.server.config.repo.ConfigRepository
@@ -16,6 +16,8 @@ import io.newm.server.features.collaboration.repo.CollaborationRepository
 import io.newm.server.features.collaboration.repo.CollaborationRepositoryImpl
 import io.newm.server.features.distribution.DistributionRepository
 import io.newm.server.features.song.model.MintingStatus
+import io.newm.server.features.song.model.Release
+import io.newm.server.features.song.model.ReleaseType
 import io.newm.server.features.song.model.Song
 import io.newm.server.features.song.repo.SongRepository
 import io.newm.server.features.song.repo.SongRepositoryImpl
@@ -35,7 +37,7 @@ import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 class EvearaDistributionRepositoryTest : BaseApplicationTests() {
     @BeforeEach
@@ -143,6 +145,14 @@ class EvearaDistributionRepositoryTest : BaseApplicationTests() {
 
         songId =
             addSongToDatabase(
+                Release(
+                    ownerId = primaryArtistId,
+                    title = "Daisuke",
+                    releaseType = ReleaseType.SINGLE,
+                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
+                    releaseDate = LocalDate.parse("2023-02-03"),
+                    publicationDate = LocalDate.parse("2023-02-03"),
+                ),
                 Song(
                     ownerId = primaryArtistId,
                     title = "Daisuke",
@@ -152,11 +162,9 @@ class EvearaDistributionRepositoryTest : BaseApplicationTests() {
                     // isrc = "QZ-NW7-23-57511",
                     moods = listOf("spiritual"),
                     coverArtUrl = "https://res.cloudinary.com/newm/image/upload/c_fit,w_4000,h_4000/v1683539164/ufshvmlfxbis0ba4bshw.jpg",
-                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
                     arweaveLyricsUrl = "ar://7vQTHTkgybn8nVLDlukGiBazy2NZVhWP6HZdJdmPH00",
                     arweaveTokenAgreementUrl = "ar://eK8gAPCvJ-9kbiP3PrSMwLGAk38aNyxPDudzzbGypxE",
                     arweaveClipUrl = "ar://QpgjmWmAHNeRVgx_Ylwvh16i3aWd8BBgyq7f16gaUu0",
-                    album = "Daisuke",
                     duration = 200000,
                     track = 1,
                     compositionCopyrightOwner = "Mirai Music Publishing",
@@ -322,8 +330,9 @@ class EvearaDistributionRepositoryTest : BaseApplicationTests() {
                 EvearaDistributionRepositoryImpl(collabRepository, configRepository)
 
             val song = songRepository.get(songId)
+            val release = songRepository.getRelease(song.releaseId!!)
 
-            distributionRepository.distributeSong(song)
+            distributionRepository.distributeRelease(release)
         }
 
     @Test

--- a/newm-server/src/test/kotlin/io/newm/server/features/marketplace/MarketplaceRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/marketplace/MarketplaceRoutesTests.kt
@@ -1,12 +1,9 @@
 package io.newm.server.features.marketplace
 
 import com.google.common.truth.Truth.assertThat
-import io.ktor.client.call.body
-import io.ktor.client.request.accept
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
 import io.newm.server.BaseApplicationTests
 import io.newm.server.features.collaboration.database.CollaborationEntity
 import io.newm.server.features.collaboration.database.CollaborationTable
@@ -15,11 +12,15 @@ import io.newm.server.features.marketplace.database.MarketplaceSaleTable
 import io.newm.server.features.marketplace.model.Sale
 import io.newm.server.features.marketplace.model.SaleStatus
 import io.newm.server.features.model.CountResponse
+import io.newm.server.features.song.database.ReleaseEntity
+import io.newm.server.features.song.database.ReleaseTable
 import io.newm.server.features.song.database.SongEntity
 import io.newm.server.features.song.database.SongTable
+import io.newm.server.features.song.model.ReleaseType
 import io.newm.server.features.user.database.UserEntity
 import io.newm.server.features.user.database.UserTable
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
 import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.deleteWhere
@@ -36,6 +37,7 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
             MarketplaceSaleTable.deleteAll()
             CollaborationTable.deleteAll()
             SongTable.deleteAll()
+            ReleaseTable.deleteAll()
             UserTable.deleteWhere { email neq testUserEmail }
         }
     }
@@ -451,12 +453,20 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
 
         val song =
             transaction {
+                val title = "title$offset ${phraseOrEmpty(3)} blah blah"
+                val releaseId =
+                    ReleaseEntity.new {
+                        ownerId = artist.id
+                        this.title = title
+                        coverArtUrl = "coverArtUrl$offset"
+                        releaseType = ReleaseType.SINGLE
+                    }.id.value
                 SongEntity.new {
                     ownerId = artist.id
-                    title = "title$offset ${phraseOrEmpty(3)}} blah blah"
+                    this.title = title
+                    this.releaseId = EntityID(releaseId, ReleaseTable)
                     genres = arrayOf("genre${offset}_0", "genre${offset}_1")
                     moods = arrayOf("mood${offset}_0", "mood${offset}_1")
-                    coverArtUrl = "coverArtUrl$offset"
                     clipUrl = "clipUrl$offset"
                     tokenAgreementUrl = "tokenAgreementUrl$offset"
                 }

--- a/newm-server/src/test/kotlin/io/newm/server/features/minting/repo/MintingRepositoryTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/minting/repo/MintingRepositoryTest.kt
@@ -19,6 +19,8 @@ import io.newm.server.features.collaboration.model.CollaborationStatus
 import io.newm.server.features.collaboration.repo.CollaborationRepository
 import io.newm.server.features.collaboration.repo.CollaborationRepositoryImpl
 import io.newm.server.features.song.model.MintingStatus
+import io.newm.server.features.song.model.Release
+import io.newm.server.features.song.model.ReleaseType
 import io.newm.server.features.song.model.Song
 import io.newm.server.features.song.repo.SongRepository
 import io.newm.server.features.song.repo.SongRepositoryImpl
@@ -35,7 +37,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 class MintingRepositoryTest : BaseApplicationTests() {
     @BeforeEach
@@ -138,19 +140,23 @@ class MintingRepositoryTest : BaseApplicationTests() {
 
         songId =
             addSongToDatabase(
+                Release(
+                    ownerId = primaryArtistId,
+                    title = "Daisuke",
+                    releaseType = ReleaseType.SINGLE,
+                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
+                    releaseDate = LocalDate.parse("2023-02-03"),
+                    publicationDate = LocalDate.parse("2023-02-03"),
+                ),
                 Song(
                     ownerId = primaryArtistId,
                     title = "Daisuke",
                     genres = listOf("Pop", "House", "Tribal"),
-                    releaseDate = LocalDate.parse("2023-02-03"),
-                    publicationDate = LocalDate.parse("2023-02-03"),
                     isrc = "QZ-NW7-23-57511",
                     moods = listOf("spiritual"),
-                    arweaveCoverArtUrl = "ar://GlMlqHIPjwUtlPUfQxDdX1jWSjlKK1BCTBIekXgA66A",
                     arweaveLyricsUrl = "ar://7vQTHTkgybn8nVLDlukGiBazy2NZVhWP6HZdJdmPH00",
                     arweaveTokenAgreementUrl = "ar://eK8gAPCvJ-9kbiP3PrSMwLGAk38aNyxPDudzzbGypxE",
                     arweaveClipUrl = "ar://QpgjmWmAHNeRVgx_Ylwvh16i3aWd8BBgyq7f16gaUu0",
-                    album = "Daisuke",
                     duration = 200000,
                     track = 1,
                     compositionCopyrightOwner = "Mirai Music Publishing",
@@ -300,6 +306,7 @@ class MintingRepositoryTest : BaseApplicationTests() {
             val mintingRepository = MintingRepositoryImpl(mockk(), collabRepository, mockk(), mockk())
 
             val song = songRepository.get(songId)
+            val release = songRepository.getRelease(song.releaseId!!)
             val primaryArtist =
                 transaction {
                     UserEntity.getByEmail("danketsu@me.com")!!.toModel(false)
@@ -320,7 +327,7 @@ class MintingRepositoryTest : BaseApplicationTests() {
                 )
 
             val plutusDataHex =
-                mintingRepository.buildStreamTokenMetadata(song, primaryArtist, collabs).toCborObject().toCborByteArray()
+                mintingRepository.buildStreamTokenMetadata(release, song, primaryArtist, collabs).toCborObject().toCborByteArray()
                     .toHexString()
 
             println("plutusDataHex: $plutusDataHex")
@@ -380,6 +387,7 @@ class MintingRepositoryTest : BaseApplicationTests() {
             val mintingRepository = MintingRepositoryImpl(mockk(), collabRepository, cardanoRepository, mockk())
 
             val song = songRepository.get(songId)
+            val release = songRepository.getRelease(song.releaseId!!)
             val primaryArtist =
                 transaction {
                     UserEntity.getByEmail("danketsu@me.com")!!.toModel(false)
@@ -399,7 +407,7 @@ class MintingRepositoryTest : BaseApplicationTests() {
                     Integer.MAX_VALUE
                 )
 
-            val cip68Metadata = mintingRepository.buildStreamTokenMetadata(song, primaryArtist, collabs)
+            val cip68Metadata = mintingRepository.buildStreamTokenMetadata(release, song, primaryArtist, collabs)
             val cashRegisterUtxos =
                 listOf(
                     utxo {

--- a/newm-server/src/test/kotlin/io/newm/server/features/song/TestSongs.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/song/TestSongs.kt
@@ -1,7 +1,7 @@
 package io.newm.server.features.song
 
 import io.newm.server.features.song.model.Song
-import io.newm.server.features.song.model.SongBarcodeType
+import io.newm.server.features.song.model.ReleaseBarcodeType
 import java.time.LocalDate
 
 val testSong1 =
@@ -12,7 +12,6 @@ val testSong1 =
         moods = listOf("Mood 1.1", "Mood 1.2"),
         coverArtUrl = "https://projectnewm.io/song1.png",
         description = "Song 1 description",
-        album = "Song 1 album",
         track = 1,
         language = "Song 1 language",
         coverRemixSample = false,
@@ -21,7 +20,7 @@ val testSong1 =
         phonographicCopyrightOwner = "Song 1 phonographicCopyrightOwner",
         phonographicCopyrightYear = 2222,
         parentalAdvisory = "Song 1 parentalAdvisory",
-        barcodeType = SongBarcodeType.Upc,
+        barcodeType = ReleaseBarcodeType.Upc,
         barcodeNumber = "Barcode 1",
         isrc = "Song 1 isrc",
         iswc = "Song 1 iswc",
@@ -39,7 +38,6 @@ val testSong2 =
         moods = listOf("Mood 2.1", "Mood 2.2"),
         coverArtUrl = "https://projectnewm.io/song2.png",
         description = "Song 2 description",
-        album = "Song 2 album",
         track = 2,
         language = "Song 2 language",
         coverRemixSample = true,
@@ -48,7 +46,7 @@ val testSong2 =
         phonographicCopyrightOwner = "Song 2 phonographicCopyrightOwner",
         phonographicCopyrightYear = 1111,
         parentalAdvisory = "Song 2 parentalAdvisory",
-        barcodeType = SongBarcodeType.Ean,
+        barcodeType = ReleaseBarcodeType.Ean,
         barcodeNumber = "Barcode 2",
         isrc = "Song 2 isrc",
         iswc = "Song 2 iswc",
@@ -56,5 +54,4 @@ val testSong2 =
         releaseDate = LocalDate.of(2023, 2, 2),
         publicationDate = LocalDate.of(2023, 2, 3),
         lyricsUrl = "https://projectnewm.io/lirycs2.txt",
-        hasSubmittedForDistribution = true,
     )


### PR DESCRIPTION
This is a fairly extensive change that introduces the concept of a "release". A release can be a single, ep, album, or compilation. 

In this first iteration of the code, we are still assuming everything is a "single" so no front-end changes need to be made.

We're just moving some things up to the release level that used to be held in the songs table. 

It's not really possible to test everything until this code gets deployed to the garage environment. Then we'll have to do extensive testing to make sure we haven't broken anything.

Having this change on the server code should allow us to manually distribute one of our albums from the sample sale to the new system.