### PR TITLE
STUD-229: fix over-encoded integers in multi-item cbor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
 allprojects {
     group = "io.newm.server"
-    version = "0.2.2-SNAPSHOT"
+    version = "0.2.3-SNAPSHOT"
 }
 
 subprojects {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,7 +15,7 @@ object Dependencies {
     }
 
     object KotlinPlugin {
-        const val VERSION = "1.9.23"
+        const val VERSION = "1.9.24"
         const val JVM_ID = "jvm"
         const val SERIALIZATION_ID = "plugin.serialization"
     }
@@ -53,7 +53,7 @@ object Dependencies {
     }
 
     object Coroutines {
-        private const val VERSION = "1.8.0"
+        private const val VERSION = "1.8.1"
 
         const val CORE = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$VERSION"
         const val JDK8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$VERSION"
@@ -65,7 +65,7 @@ object Dependencies {
     }
 
     object Ktor {
-        private const val VERSION = "2.3.10"
+        private const val VERSION = "2.3.11"
 
         const val SERVER_CORE = "io.ktor:ktor-server-core:$VERSION"
         const val SERVER_CIO = "io.ktor:ktor-server-cio:$VERSION"
@@ -132,7 +132,7 @@ object Dependencies {
     }
 
     object FlywayDB {
-        private const val VERSION = "10.11.1"
+        private const val VERSION = "10.12.0"
 
         const val CORE = "org.flywaydb:flyway-core:$VERSION"
         const val POSTGRES = "org.flywaydb:flyway-database-postgresql:$VERSION"
@@ -159,7 +159,7 @@ object Dependencies {
     }
 
     object ApacheCommonsCodec {
-        private const val VERSION = "1.16.1"
+        private const val VERSION = "1.17.0"
 
         const val ALL = "commons-codec:commons-codec:$VERSION"
     }
@@ -214,8 +214,8 @@ object Dependencies {
     }
 
     object Aws {
-        private const val VERSION = "1.12.709"
-        private const val VERSION2 = "2.25.39"
+        private const val VERSION = "1.12.720"
+        private const val VERSION2 = "2.25.50"
         private const val JAXB_VERSION = "2.3.1"
 
         const val BOM = "com.amazonaws:aws-java-sdk-bom:$VERSION"
@@ -249,7 +249,7 @@ object Dependencies {
     }
 
     object Cbor {
-        private const val VERSION = "0.2.1-NEWM"
+        private const val VERSION = "0.2.2-NEWM"
 
         const val CBOR = "io.newm:com.google.iot.cbor:$VERSION"
     }
@@ -267,7 +267,7 @@ object Dependencies {
     }
 
     object Sentry {
-        private const val VERSION = "7.8.0"
+        private const val VERSION = "7.9.0"
 
         const val CORE = "io.sentry:sentry:$VERSION"
         const val LOGBACK = "io.sentry:sentry-logback:$VERSION"
@@ -311,14 +311,14 @@ object Dependencies {
     }
 
     object SSLKickstart {
-        private const val VERSION = "8.3.4"
+        private const val VERSION = "8.3.5"
 
         const val PEM = "io.github.hakky54:sslcontext-kickstart-for-pem:$VERSION"
         const val NETTY = "io.github.hakky54:sslcontext-kickstart-for-netty:$VERSION"
     }
 
     object TestContainers {
-        private const val VERSION = "1.19.7"
+        private const val VERSION = "1.19.8"
 
         const val CORE = "org.testcontainers:testcontainers:$VERSION"
         const val JUINT = "org.testcontainers:junit-jupiter:$VERSION"

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/repo/CollaborationRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/repo/CollaborationRepositoryImpl.kt
@@ -213,7 +213,7 @@ internal class CollaborationRepositoryImpl(
         songId: SongId,
         getCollaborations: Transaction.() -> Iterable<CollaborationEntity>
     ) {
-        val emails = mutableListOf<String>()
+        val emails = mutableSetOf<String>()
         val song =
             transaction {
                 val song = SongEntity[songId]
@@ -232,7 +232,7 @@ internal class CollaborationRepositoryImpl(
         if (emails.isNotEmpty()) {
             emailRepository.send(
                 to = emptyList(),
-                bcc = emails,
+                bcc = emails.toList(),
                 subject = environment.getConfigString("collaboration.email.subject"),
                 messageUrl = environment.getConfigString("collaboration.email.messageUrl"),
                 messageArgs =

--- a/newm-server/src/main/kotlin/io/newm/server/features/email/repo/EmailRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/email/repo/EmailRepositoryImpl.kt
@@ -3,15 +3,7 @@ package io.newm.server.features.email.repo
 import io.ktor.server.application.ApplicationEnvironment
 import io.newm.server.ktx.getSecureString
 import io.newm.shared.koin.inject
-import io.newm.shared.ktx.debug
-import io.newm.shared.ktx.error
-import io.newm.shared.ktx.format
-import io.newm.shared.ktx.getBoolean
-import io.newm.shared.ktx.getChild
-import io.newm.shared.ktx.getConfigChild
-import io.newm.shared.ktx.getInt
-import io.newm.shared.ktx.toUrl
-import io.newm.shared.ktx.warn
+import io.newm.shared.ktx.*
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.apache.commons.mail.DefaultAuthenticator
@@ -66,6 +58,8 @@ internal class EmailRepositoryImpl(
                                 this.subject = subject
                                 setHtmlMsg(message)
                             }.send()
+
+                            logger.info { "Email sent to: $to, bcc: $bcc, subject: $subject" }
                         } else {
                             logger.warn { "Email notifications disabled - skipped sending message" }
                         }

--- a/newm-tx-builder/src/main/kotlin/io/newm/txbuilder/ktx/PlutusDataKtx.kt
+++ b/newm-tx-builder/src/main/kotlin/io/newm/txbuilder/ktx/PlutusDataKtx.kt
@@ -122,7 +122,7 @@ fun PlutusData.toCborObject(): CborObject {
                     bytes.toByteArray().asList().chunked(64).map { chunk ->
                         chunk.toByteArray()
                     }.toTypedArray()
-                CborByteString.wrap(chunks, cborTag, true)
+                CborByteString.wrap(chunks, cborTag, true, null)
             } else {
                 CborByteString.create(
                     bytes.toByteArray(),


### PR DESCRIPTION
The fix is to pull in the new Cbor 0.2.2-NEWM version of the library. Other changes are code cleanup/tweaks.