### PR TITLE
minor: STUD-149 Update the code so that we continue checking Eveara s…

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/config/repo/ConfigRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/config/repo/ConfigRepository.kt
@@ -48,6 +48,7 @@ interface ConfigRepository {
         const val CONFIG_KEY_EVEARA_PARTNER_SUBSCRIPTION_ID = "eveara.partnerSubscriptionId"
         const val CONFIG_KEY_EVEARA_NEWM_EMAIL = "eveara.newmEmail"
         const val CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES = "eveara.statusCheckMinutes"
+        const val CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE = "eveara.statusCheckRefire"
         const val CONFIG_KEY_EMAIL_WHITELIST = "email.whitelist"
         const val CONFIG_KEY_DISTRIBUTION_PRICE_USD = "distribution.price.usd"
         const val CONFIG_KEY_OUTLET_STATUS_CHECK_MINUTES = "outlet.statusCheckMinutes"

--- a/newm-server/src/main/kotlin/io/newm/server/config/repo/ConfigRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/config/repo/ConfigRepository.kt
@@ -48,7 +48,7 @@ interface ConfigRepository {
         const val CONFIG_KEY_EVEARA_PARTNER_SUBSCRIPTION_ID = "eveara.partnerSubscriptionId"
         const val CONFIG_KEY_EVEARA_NEWM_EMAIL = "eveara.newmEmail"
         const val CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES = "eveara.statusCheckMinutes"
-        const val CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE = "eveara.statusCheckRefire"
+        const val CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE = "eveara.statusCheckDeclinedMaxRefire"
         const val CONFIG_KEY_EMAIL_WHITELIST = "email.whitelist"
         const val CONFIG_KEY_DISTRIBUTION_PRICE_USD = "distribution.price.usd"
         const val CONFIG_KEY_OUTLET_STATUS_CHECK_MINUTES = "outlet.statusCheckMinutes"

--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V31__ConfigUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V31__ConfigUpdates.kt
@@ -9,11 +9,9 @@ import org.jetbrains.exposed.sql.transactions.transaction
 class V31__ConfigUpdates : BaseJavaMigration() {
     override fun migrate(context: Context?) {
         transaction {
-            execInBatch(
-                listOf(
-                    // default 24 hours
-                    "INSERT INTO config VALUES ('$CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES','1440') ON CONFLICT(id) DO NOTHING",
-                )
+            exec(
+                // default 24 hours
+                "INSERT INTO config VALUES ('$CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES','1440') ON CONFLICT(id) DO NOTHING",
             )
         }
     }

--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V32__ConfigUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V32__ConfigUpdates.kt
@@ -1,0 +1,20 @@
+package io.newm.server.database.migration
+
+import io.newm.server.config.repo.ConfigRepository.Companion.CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("unused")
+class V32__ConfigUpdates : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            execInBatch(
+                listOf(
+                    // default 24 hours
+                    "INSERT INTO config VALUES ('$CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE','60') ON CONFLICT(id) DO NOTHING",
+                )
+            )
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V32__ConfigUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V32__ConfigUpdates.kt
@@ -9,11 +9,9 @@ import org.jetbrains.exposed.sql.transactions.transaction
 class V32__ConfigUpdates : BaseJavaMigration() {
     override fun migrate(context: Context?) {
         transaction {
-            execInBatch(
-                listOf(
-                    // Check album status every 720(minutes) X 30(days) = 21600 minutes
-                    "INSERT INTO config VALUES ('$CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE','21600') ON CONFLICT(id) DO NOTHING",
-                )
+            exec(
+                // Check album status every 720(minutes) X 30(days) = 21600 minutes
+                "INSERT INTO config VALUES ('$CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE','21600') ON CONFLICT(id) DO NOTHING",
             )
         }
     }

--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V32__ConfigUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V32__ConfigUpdates.kt
@@ -11,8 +11,8 @@ class V32__ConfigUpdates : BaseJavaMigration() {
         transaction {
             execInBatch(
                 listOf(
-                    // default 24 hours
-                    "INSERT INTO config VALUES ('$CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE','60') ON CONFLICT(id) DO NOTHING",
+                    // Check album status every 720(minutes) X 30(days) = 21600 minutes
+                    "INSERT INTO config VALUES ('$CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE','21600') ON CONFLICT(id) DO NOTHING",
                 )
             )
         }

--- a/newm-server/src/main/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJob.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJob.kt
@@ -1,6 +1,7 @@
 package io.newm.server.features.scheduler
 
 import io.newm.server.config.repo.ConfigRepository
+import io.newm.server.config.repo.ConfigRepository.Companion.CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES
 import io.newm.server.config.repo.ConfigRepository.Companion.CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE
 import io.newm.server.features.cardano.repo.CardanoRepository
 import io.newm.server.features.distribution.DistributionRepository
@@ -104,7 +105,11 @@ class EvearaReleaseStatusJob : Job {
                                 "Failed to get album disapproveMessage"
                             )
                         }
-                        if (context.refireCount > configRepository.getInt(CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE)) {
+                        if (context.refireCount *
+                            configRepository.getInt(
+                                CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES
+                            ) > configRepository.getInt(CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE)
+                        ) {
                             // Cancel this job's future executions
                             context.scheduler.deleteJob(
                                 JobKey.jobKey(

--- a/newm-server/src/main/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJob.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJob.kt
@@ -118,7 +118,7 @@ class EvearaReleaseStatusJob : Job {
                                 )
                             )
                         } else {
-                            log.info { "Keep job ${context.jobDetail.key.name} in the schedule, re-fire count is: ${context.refireCount}" }
+                            log.debug("Keep job ${context.jobDetail.key.name} in the schedule, re-fire count is: ${context.refireCount}")
                         }
                     }
 

--- a/newm-server/src/test/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJobTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJobTest.kt
@@ -1,0 +1,153 @@
+package io.newm.server.features.scheduler
+
+import io.mockk.*
+import io.mockk.junit5.MockKExtension
+import io.newm.server.config.repo.ConfigRepository
+import io.newm.server.features.cardano.repo.CardanoRepository
+import io.newm.server.features.distribution.DistributionRepository
+import io.newm.server.features.song.model.Release
+import io.newm.server.features.song.model.Song
+import io.newm.server.features.song.repo.SongRepository
+import io.newm.server.features.user.model.User
+import io.newm.server.features.user.repo.UserRepository
+import io.newm.server.typealiases.ReleaseId
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.quartz.JobDataMap
+import org.quartz.JobExecutionContext
+import org.quartz.JobKey
+import org.quartz.Scheduler
+import org.quartz.impl.JobDetailImpl
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@ExtendWith(MockKExtension::class)
+class EvearaReleaseStatusJobTest : KoinTest {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun beforeAll() {
+            // initialize Koin dependency injection for tests
+            val userRepo = mockk<UserRepository>(relaxed = true)
+            val user =
+                User(
+                    firstName = "Danketsu",
+                    lastName = "",
+                    genre = "House",
+                    role = "Artist",
+                    email = "danketsu@me.com",
+                    nickname = "Danketsu",
+                    websiteUrl = "https://danketsu.io",
+                    instagramUrl = "https://instagram.com/danketsu",
+                    twitterUrl = "https://twitter.com/danketsu",
+                    // FIXME: This fails at Eveara because their spotify name is "Ada Ninjaz" and not "Danketsu"
+                    spotifyProfile = "https://open.spotify.com/artist/4EiSbT0iP4YARJ9MGClRgB",
+                )
+            coEvery { userRepo.get(any()) } coAnswers { user }
+
+            // Mock SongRepository
+            val songRepo = mockk<SongRepository>(relaxed = true)
+            val release = Release(forceDistributed = true, distributionReleaseId = 12)
+            val song = Song(releaseId = ReleaseId.randomUUID(), title = "[DistributionFailure]")
+            coEvery { songRepo.get(any()) } coAnswers { song }
+            coEvery { songRepo.getRelease(any()) } coAnswers { release }
+
+            // Mock ConfigRepository
+            val configRepository = mockk<ConfigRepository>(relaxed = true)
+            coEvery { configRepository.getInt(any()) } coAnswers { 30 }
+
+            startKoin {
+                modules(
+                    module {
+                        // inject mocks
+                        single<Logger> { LoggerFactory.getLogger("UtilTest") }
+                        single {
+                            Json {
+                                ignoreUnknownKeys = true
+                                explicitNulls = false
+                                isLenient = true
+                            }
+                        }
+                        single {
+                            mockk<DistributionRepository>(relaxed = true) {
+                            }
+                        }
+                        single { mockk<CardanoRepository>(relaxed = true) }
+                        single { userRepo }
+                        single { songRepo }
+                        single { configRepository }
+                    }
+                )
+            }
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun afterAll() {
+            // close Koin
+            stopKoin()
+        }
+    }
+
+    var evearaReleaseStatusJob: EvearaReleaseStatusJob = EvearaReleaseStatusJob()
+
+    @Test
+    fun `test when refire count is less than CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE`() =
+        runTest {
+            // var evearaReleaseStatusJob: EvearaReleaseStatusJob = EvearaReleaseStatusJob()
+            var dataMp: JobDataMap = JobDataMap()
+            dataMp.put("userId", "20073f71-6c95-4565-89f4-c1640657086c")
+            dataMp.put("songId", "82a37c5f-525a-416a-ba34-6eaa8a5a486c")
+            val mockJobExecutionContext = mockk<JobExecutionContext>(relaxed = true)
+            every { mockJobExecutionContext.mergedJobDataMap } returns dataMp
+            // create JobDetail
+            var jobDetail = JobDetailImpl()
+            jobDetail.group = "refire"
+            jobDetail.name = "refire-test"
+            every { mockJobExecutionContext.jobDetail } returns jobDetail
+
+            // Mock Scheduler
+            val mockScheduler = mockk<Scheduler>(relaxed = true)
+            every { mockJobExecutionContext.scheduler } returns mockScheduler
+
+            evearaReleaseStatusJob.execute(mockJobExecutionContext)
+            var jobKey = JobKey("refire-test", "refire")
+            verify { mockScheduler wasNot Called }
+
+            // verify { mockScheduler.deleteJob(jobKey) }
+        }
+
+    @Test
+    fun `test when refire count is greater than CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE`() =
+        runTest {
+            // var evearaReleaseStatusJob: EvearaReleaseStatusJob = EvearaReleaseStatusJob()
+            var dataMp: JobDataMap = JobDataMap()
+            dataMp.put("userId", "20073f71-6c95-4565-89f4-c1640657086c")
+            dataMp.put("songId", "82a37c5f-525a-416a-ba34-6eaa8a5a486c")
+            val mockJobExecutionContext = mockk<JobExecutionContext>(relaxed = true)
+            every { mockJobExecutionContext.mergedJobDataMap } returns dataMp
+            every { mockJobExecutionContext.refireCount } returns 61
+            // create JobDetail
+            var jobDetail = JobDetailImpl()
+            jobDetail.group = "refire"
+            jobDetail.name = "refire-test"
+            every { mockJobExecutionContext.jobDetail } returns jobDetail
+
+            // Mock Scheduler
+            val mockScheduler = mockk<Scheduler>(relaxed = true)
+            every { mockJobExecutionContext.scheduler } returns mockScheduler
+
+            evearaReleaseStatusJob.execute(mockJobExecutionContext)
+            var jobKey = JobKey("refire-test", "refire")
+
+            verify { mockScheduler.deleteJob(jobKey) }
+        }
+}

--- a/newm-server/src/test/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJobTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/scheduler/EvearaReleaseStatusJobTest.kt
@@ -3,6 +3,8 @@ package io.newm.server.features.scheduler
 import io.mockk.*
 import io.mockk.junit5.MockKExtension
 import io.newm.server.config.repo.ConfigRepository
+import io.newm.server.config.repo.ConfigRepository.Companion.CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES
+import io.newm.server.config.repo.ConfigRepository.Companion.CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE
 import io.newm.server.features.cardano.repo.CardanoRepository
 import io.newm.server.features.distribution.DistributionRepository
 import io.newm.server.features.song.model.Release
@@ -62,7 +64,8 @@ class EvearaReleaseStatusJobTest : KoinTest {
 
             // Mock ConfigRepository
             val configRepository = mockk<ConfigRepository>(relaxed = true)
-            coEvery { configRepository.getInt(any()) } coAnswers { 30 }
+            coEvery { configRepository.getInt(CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES) } coAnswers { 720 }
+            coEvery { configRepository.getInt(CONFIG_KEY_EVEARA_STATUS_CHECK_REFIRE) } coAnswers { 21600 }
 
             startKoin {
                 modules(


### PR DESCRIPTION
**Description**

We currently stop checking Eveara status on a song once it enters a Declined state. Usually what happens is we open a ticket with Eveara and then it eventually moves into a Distributed state once any issues are resolved.

Update the code so that we continue checking Eveara status for up to 30 days before we give up and stop checking.


**Details:** 

I'm thinking about using context.refireCount to figure out when to remove the job from the scheduler and stop polling album status, so based on CONFIG_KEY_EVEARA_STATUS_CHECK_MINUTES we can do a simple math, if we want to keep job in scheduler for 30 days in production, we can check if refirecount is < 60
https://www.quartz-scheduler.org/api/2.1.7/org/quartz/JobExecutionContext.html#getRefireCount()
That's one approach ^^
Second approach to put a new key in job context to keep track of the day it was added to the scheduler and compare it to today's date, and if it's age is greater than 30 days, remove it from scheduler



