### PR TITLE
MRKT-72 | Support exclusion via API filter params

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/cardano/repo/CardanoRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/cardano/repo/CardanoRepositoryImpl.kt
@@ -9,8 +9,34 @@ import com.amazonaws.services.kms.model.EncryptResult
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.google.protobuf.ByteString
 import io.ktor.network.util.DefaultByteBufferPool
-import io.newm.chain.grpc.*
+import io.newm.chain.grpc.IsMainnetRequest
+import io.newm.chain.grpc.LedgerAssetMetadataItem
+import io.newm.chain.grpc.MonitorAddressResponse
+import io.newm.chain.grpc.MonitorPaymentAddressRequest
+import io.newm.chain.grpc.NativeAsset
 import io.newm.chain.grpc.NewmChainGrpcKt.NewmChainCoroutineStub
+import io.newm.chain.grpc.SnapshotNativeAssetsResponse
+import io.newm.chain.grpc.SubmitTransactionResponse
+import io.newm.chain.grpc.TransactionBuilderRequestKt
+import io.newm.chain.grpc.TransactionBuilderResponse
+import io.newm.chain.grpc.Utxo
+import io.newm.chain.grpc.VerifySignDataResponse
+import io.newm.chain.grpc.acquireMutexRequest
+import io.newm.chain.grpc.datumOrNull
+import io.newm.chain.grpc.listOrNull
+import io.newm.chain.grpc.mapItemValueOrNull
+import io.newm.chain.grpc.mapOrNull
+import io.newm.chain.grpc.monitorAddressRequest
+import io.newm.chain.grpc.nativeAsset
+import io.newm.chain.grpc.outputUtxo
+import io.newm.chain.grpc.queryByNativeAssetRequest
+import io.newm.chain.grpc.queryUtxosOutputRefRequest
+import io.newm.chain.grpc.queryUtxosRequest
+import io.newm.chain.grpc.releaseMutexRequest
+import io.newm.chain.grpc.snapshotNativeAssetsRequest
+import io.newm.chain.grpc.submitTransactionRequest
+import io.newm.chain.grpc.verifySignDataRequest
+import io.newm.chain.grpc.walletRequest
 import io.newm.chain.util.Constants
 import io.newm.chain.util.b64ToByteArray
 import io.newm.chain.util.toB64String
@@ -33,6 +59,7 @@ import io.newm.server.features.song.model.SongFilters
 import io.newm.server.features.song.repo.SongRepository
 import io.newm.server.features.walletconnection.database.WalletConnectionEntity
 import io.newm.server.ktx.cborHexToUtxo
+import io.newm.server.model.FilterCriteria
 import io.newm.server.typealiases.UserId
 import io.newm.shared.koin.inject
 import io.newm.shared.ktx.debug
@@ -331,7 +358,7 @@ internal class CardanoRepositoryImpl(
                         moods = null,
                         mintingStatuses = null,
                         phrase = null,
-                        nftNames = streamTokenNames,
+                        nftNames = FilterCriteria(includes = streamTokenNames)
                     )
             )
         val songs =
@@ -348,7 +375,7 @@ internal class CardanoRepositoryImpl(
                         moods = null,
                         mintingStatuses = null,
                         phrase = null,
-                        nftNames = streamTokenNames,
+                        nftNames = FilterCriteria(includes = streamTokenNames),
                     ),
                 offset = offset,
                 limit = limit,

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/database/CollaborationEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/database/CollaborationEntity.kt
@@ -23,6 +23,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.count
 import org.jetbrains.exposed.sql.innerJoin
@@ -106,17 +107,29 @@ class CollaborationEntity(id: EntityID<UUID>) : UUIDEntity(id) {
                 newerThan?.let {
                     ops += CollaborationTable.createdAt greater it
                 }
-                ids?.let {
+                ids?.includes?.let {
                     ops += CollaborationTable.id inList it
                 }
-                songIds?.let {
+                ids?.excludes?.let {
+                    ops += CollaborationTable.id notInList it
+                }
+                songIds?.includes?.let {
                     ops += CollaborationTable.songId inList it
                 }
-                emails?.let {
+                songIds?.excludes?.let {
+                    ops += CollaborationTable.songId notInList it
+                }
+                emails?.includes?.let {
                     ops += CollaborationTable.email.lowerCase() inList it.map(String::lowercase)
                 }
-                statuses?.let {
+                emails?.excludes?.let {
+                    ops += CollaborationTable.email.lowerCase() notInList it.map(String::lowercase)
+                }
+                statuses?.includes?.let {
                     ops += CollaborationTable.status inList it
+                }
+                statuses?.excludes?.let {
+                    ops += CollaborationTable.status notInList it
                 }
             }
             val andOp = AndOp(ops)
@@ -148,11 +161,17 @@ class CollaborationEntity(id: EntityID<UUID>) : UUIDEntity(id) {
                 if (excludeMe == true) {
                     ops += CollaborationTable.email.lowerCase() neq UserEntity[userId].email.lowercase()
                 }
-                songIds?.let {
+                songIds?.includes?.let {
                     ops += CollaborationTable.songId inList it
                 }
-                emails?.let {
+                songIds?.excludes?.let {
+                    ops += CollaborationTable.songId notInList it
+                }
+                emails?.includes?.let {
                     ops += CollaborationTable.email.lowerCase() inList it.map(String::lowercase)
+                }
+                emails?.excludes?.let {
+                    ops += CollaborationTable.email.lowerCase() notInList it.map(String::lowercase)
                 }
                 phrase?.let {
                     val pattern = "%${it.lowercase()}%"

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/model/CollaborationFilters.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/model/CollaborationFilters.kt
@@ -7,7 +7,8 @@ import io.newm.server.ktx.newerThan
 import io.newm.server.ktx.olderThan
 import io.newm.server.ktx.songIds
 import io.newm.server.ktx.sortOrder
-import io.newm.shared.ktx.splitAndTrim
+import io.newm.server.model.FilterCriteria
+import io.newm.server.model.toFilterCriteria
 import org.jetbrains.exposed.sql.SortOrder
 import java.time.LocalDateTime
 import java.util.UUID
@@ -17,17 +18,17 @@ data class CollaborationFilters(
     val inbound: Boolean? = null,
     val olderThan: LocalDateTime? = null,
     val newerThan: LocalDateTime? = null,
-    val ids: List<UUID>? = null,
-    val songIds: List<UUID>? = null,
-    val emails: List<String>? = null,
-    val statuses: List<CollaborationStatus>? = null
+    val ids: FilterCriteria<UUID>? = null,
+    val songIds: FilterCriteria<UUID>? = null,
+    val emails: FilterCriteria<String>? = null,
+    val statuses: FilterCriteria<CollaborationStatus>? = null
 )
 
 val ApplicationCall.inbound: Boolean?
     get() = parameters["inbound"]?.toBoolean()
 
-val ApplicationCall.statuses: List<CollaborationStatus>?
-    get() = parameters["statuses"]?.splitAndTrim()?.map(CollaborationStatus::valueOf)
+val ApplicationCall.statuses: FilterCriteria<CollaborationStatus>?
+    get() = parameters["statuses"]?.toFilterCriteria(CollaborationStatus::valueOf)
 
 val ApplicationCall.collaborationFilters: CollaborationFilters
     get() = CollaborationFilters(sortOrder, inbound, olderThan, newerThan, ids, songIds, emails, statuses)

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/model/CollaboratorFilters.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/model/CollaboratorFilters.kt
@@ -5,14 +5,15 @@ import io.newm.server.ktx.emails
 import io.newm.server.ktx.phrase
 import io.newm.server.ktx.songIds
 import io.newm.server.ktx.sortOrder
+import io.newm.server.model.FilterCriteria
 import org.jetbrains.exposed.sql.SortOrder
 import java.util.UUID
 
 data class CollaboratorFilters(
     val sortOrder: SortOrder? = null,
     val excludeMe: Boolean? = null,
-    val songIds: List<UUID>? = null,
-    val emails: List<String>? = null,
+    val songIds: FilterCriteria<UUID>? = null,
+    val emails: FilterCriteria<String>? = null,
     val phrase: String? = null
 )
 

--- a/newm-server/src/main/kotlin/io/newm/server/features/collaboration/repo/CollaborationRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/collaboration/repo/CollaborationRepositoryImpl.kt
@@ -16,6 +16,7 @@ import io.newm.server.features.user.database.UserEntity
 import io.newm.server.ktx.asMandatoryField
 import io.newm.server.ktx.asValidEmail
 import io.newm.server.ktx.checkLength
+import io.newm.server.model.FilterCriteria
 import io.newm.server.typealiases.SongId
 import io.newm.server.typealiases.UserId
 import io.newm.shared.exception.HttpConflictException
@@ -172,7 +173,7 @@ internal class CollaborationRepositoryImpl(
     override suspend fun getAllBySongId(songId: SongId): List<Collaboration> =
         getAll(
             userId = transaction { SongEntity[songId].ownerId.value },
-            filters = CollaborationFilters(songIds = listOf(songId)),
+            filters = CollaborationFilters(songIds = FilterCriteria(includes = listOf(songId))),
             offset = 0,
             limit = Integer.MAX_VALUE
         )

--- a/newm-server/src/main/kotlin/io/newm/server/features/marketplace/database/MarketplaceSaleEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/marketplace/database/MarketplaceSaleEntity.kt
@@ -12,6 +12,7 @@ import io.newm.server.features.song.database.SongTable
 import io.newm.server.features.user.database.UserEntity
 import io.newm.server.features.user.database.UserTable
 import io.newm.server.ktx.arweaveToWebUrl
+import io.newm.shared.exposed.notOverlaps
 import io.newm.shared.exposed.overlaps
 import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
@@ -25,6 +26,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.innerJoin
 import org.jetbrains.exposed.sql.lowerCase
@@ -141,23 +143,41 @@ class MarketplaceSaleEntity(id: EntityID<UUID>) : UUIDEntity(id) {
             newerThan?.let {
                 ops += MarketplaceSaleTable.createdAt greater it
             }
-            ids?.let {
+            ids?.includes?.let {
                 ops += MarketplaceSaleTable.id inList it
             }
-            songIds?.let {
+            ids?.excludes?.let {
+                ops += MarketplaceSaleTable.id notInList it
+            }
+            songIds?.includes?.let {
                 ops += MarketplaceSaleTable.songId inList it
             }
-            artistIds?.let {
+            songIds?.excludes?.let {
+                ops += MarketplaceSaleTable.songId notInList it
+            }
+            artistIds?.includes?.let {
                 ops += UserTable.id inList it
             }
-            statuses?.let {
+            artistIds?.excludes?.let {
+                ops += UserTable.id notInList it
+            }
+            statuses?.includes?.let {
                 ops += MarketplaceSaleTable.status inList it
             }
-            genres?.let {
+            statuses?.excludes?.let {
+                ops += MarketplaceSaleTable.status notInList it
+            }
+            genres?.includes?.let {
                 ops += SongTable.genres overlaps it.toTypedArray()
             }
-            moods?.let {
+            genres?.excludes?.let {
+                ops += SongTable.genres notOverlaps it.toTypedArray()
+            }
+            moods?.includes?.let {
                 ops += SongTable.moods overlaps it.toTypedArray()
+            }
+            moods?.excludes?.let {
+                ops += SongTable.moods notOverlaps it.toTypedArray()
             }
             phrase?.let {
                 val pattern = "%${it.lowercase()}%"

--- a/newm-server/src/main/kotlin/io/newm/server/features/marketplace/model/SaleFilters.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/marketplace/model/SaleFilters.kt
@@ -8,9 +8,10 @@ import io.newm.server.ktx.moods
 import io.newm.server.ktx.newerThan
 import io.newm.server.ktx.olderThan
 import io.newm.server.ktx.phrase
-import io.newm.server.ktx.saleStatuses
 import io.newm.server.ktx.songIds
 import io.newm.server.ktx.sortOrder
+import io.newm.server.model.FilterCriteria
+import io.newm.server.model.toFilterCriteria
 import org.jetbrains.exposed.sql.SortOrder
 import java.time.LocalDateTime
 import java.util.UUID
@@ -19,14 +20,17 @@ data class SaleFilters(
     val sortOrder: SortOrder?,
     val olderThan: LocalDateTime?,
     val newerThan: LocalDateTime?,
-    val ids: List<UUID>?,
-    val songIds: List<UUID>?,
-    val artistIds: List<UUID>?,
-    val statuses: List<SaleStatus>?,
-    val genres: List<String>?,
-    val moods: List<String>?,
+    val ids: FilterCriteria<UUID>?,
+    val songIds: FilterCriteria<UUID>?,
+    val artistIds: FilterCriteria<UUID>?,
+    val statuses: FilterCriteria<SaleStatus>?,
+    val genres: FilterCriteria<String>?,
+    val moods: FilterCriteria<String>?,
     val phrase: String?
 )
+
+val ApplicationCall.saleStatuses: FilterCriteria<SaleStatus>?
+    get() = parameters["saleStatuses"]?.toFilterCriteria(SaleStatus::valueOf)
 
 val ApplicationCall.saleFilters: SaleFilters
     get() = SaleFilters(sortOrder, olderThan, newerThan, ids, songIds, artistIds, saleStatuses, genres, moods, phrase)

--- a/newm-server/src/main/kotlin/io/newm/server/features/playlist/database/PlaylistEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/playlist/database/PlaylistEntity.kt
@@ -16,6 +16,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
@@ -59,11 +60,17 @@ class PlaylistEntity(id: EntityID<UUID>) : UUIDEntity(id) {
                 newerThan?.let {
                     ops += PlaylistTable.createdAt greater it
                 }
-                ids?.let {
+                ids?.includes?.let {
                     ops += PlaylistTable.id inList it
                 }
-                ownerIds?.let {
+                ids?.excludes?.let {
+                    ops += PlaylistTable.id notInList it
+                }
+                ownerIds?.includes?.let {
                     ops += PlaylistTable.ownerId inList it
+                }
+                ownerIds?.excludes?.let {
+                    ops += PlaylistTable.ownerId notInList it
                 }
             }
             return (if (ops.isEmpty()) all() else find(AndOp(ops)))

--- a/newm-server/src/main/kotlin/io/newm/server/features/playlist/model/PlaylistFilters.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/playlist/model/PlaylistFilters.kt
@@ -6,6 +6,7 @@ import io.newm.server.ktx.newerThan
 import io.newm.server.ktx.olderThan
 import io.newm.server.ktx.ownerIds
 import io.newm.server.ktx.sortOrder
+import io.newm.server.model.FilterCriteria
 import org.jetbrains.exposed.sql.SortOrder
 import java.time.LocalDateTime
 import java.util.UUID
@@ -14,8 +15,8 @@ data class PlaylistFilters(
     val sortOrder: SortOrder?,
     val olderThan: LocalDateTime?,
     val newerThan: LocalDateTime?,
-    val ids: List<UUID>?,
-    val ownerIds: List<UUID>?
+    val ids: FilterCriteria<UUID>?,
+    val ownerIds: FilterCriteria<UUID>?
 )
 
 val ApplicationCall.playlistFilters: PlaylistFilters

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseEntity.kt
@@ -17,9 +17,9 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
 
 class ReleaseEntity(id: EntityID<ReleaseId>) : UUIDEntity(id) {
     var archived: Boolean by ReleaseTable.archived
@@ -94,11 +94,17 @@ class ReleaseEntity(id: EntityID<ReleaseId>) : UUIDEntity(id) {
             newerThan?.let {
                 ops += ReleaseTable.createdAt greater it
             }
-            ids?.let {
+            ids?.includes?.let {
                 ops += ReleaseTable.id inList it
             }
-            ownerIds?.let {
+            ids?.excludes?.let {
+                ops += ReleaseTable.id notInList it
+            }
+            ownerIds?.includes?.let {
                 ops += ReleaseTable.ownerId inList it
+            }
+            ownerIds?.excludes?.let {
+                ops += ReleaseTable.ownerId notInList it
             }
             phrase?.let {
                 val pattern = "%${it.lowercase()}%"

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/model/SongFilters.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/model/SongFilters.kt
@@ -4,14 +4,15 @@ import io.ktor.server.application.ApplicationCall
 import io.newm.server.ktx.archived
 import io.newm.server.ktx.genres
 import io.newm.server.ktx.ids
-import io.newm.server.ktx.mintingStatuses
 import io.newm.server.ktx.moods
 import io.newm.server.ktx.newerThan
-import io.newm.server.ktx.nftNames
 import io.newm.server.ktx.olderThan
 import io.newm.server.ktx.ownerIds
 import io.newm.server.ktx.phrase
 import io.newm.server.ktx.sortOrder
+import io.newm.server.model.FilterCriteria
+import io.newm.server.model.toFilterCriteria
+import io.newm.server.model.toStringFilterCriteria
 import org.jetbrains.exposed.sql.SortOrder
 import java.time.LocalDateTime
 import java.util.UUID
@@ -21,14 +22,20 @@ data class SongFilters(
     val sortOrder: SortOrder?,
     val olderThan: LocalDateTime?,
     val newerThan: LocalDateTime?,
-    val ids: List<UUID>?,
-    val ownerIds: List<UUID>?,
-    val genres: List<String>?,
-    val moods: List<String>?,
-    val mintingStatuses: List<MintingStatus>?,
+    val ids: FilterCriteria<UUID>?,
+    val ownerIds: FilterCriteria<UUID>?,
+    val genres: FilterCriteria<String>?,
+    val moods: FilterCriteria<String>?,
+    val mintingStatuses: FilterCriteria<MintingStatus>?,
+    val nftNames: FilterCriteria<String>?,
     val phrase: String?,
-    val nftNames: List<String>?,
 )
+
+val ApplicationCall.mintingStatuses: FilterCriteria<MintingStatus>?
+    get() = parameters["mintingStatuses"]?.toFilterCriteria(MintingStatus::valueOf)
+
+val ApplicationCall.nftNames: FilterCriteria<String>?
+    get() = parameters["nftNames"]?.toStringFilterCriteria()
 
 val ApplicationCall.songFilters: SongFilters
     get() =
@@ -42,6 +49,6 @@ val ApplicationCall.songFilters: SongFilters
             genres,
             moods,
             mintingStatuses,
+            nftNames,
             phrase,
-            nftNames
         )

--- a/newm-server/src/main/kotlin/io/newm/server/features/user/database/UserEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/user/database/UserEntity.kt
@@ -9,10 +9,15 @@ import io.newm.shared.ktx.exists
 import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.AndOp
+import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.SizedIterable
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
+import org.jetbrains.exposed.sql.lowerCase
 import java.time.LocalDateTime
 
 class UserEntity(id: EntityID<UserId>) : UUIDEntity(id) {
@@ -107,14 +112,23 @@ class UserEntity(id: EntityID<UserId>) : UUIDEntity(id) {
                 newerThan?.let {
                     ops += UserTable.createdAt greater it
                 }
-                ids?.let {
+                ids?.includes?.let {
                     ops += UserTable.id inList it
                 }
-                roles?.let {
+                ids?.excludes?.let {
+                    ops += UserTable.id notInList it
+                }
+                roles?.includes?.let {
                     ops += UserTable.role inList it
                 }
-                genres?.let {
+                roles?.excludes?.let {
+                    ops += UserTable.role notInList it
+                }
+                genres?.includes?.let {
                     ops += UserTable.genre inList it
+                }
+                genres?.excludes?.let {
+                    ops += UserTable.genre notInList it
                 }
             }
             return (if (ops.isEmpty()) all() else find(AndOp(ops)))

--- a/newm-server/src/main/kotlin/io/newm/server/features/user/model/UserFilters.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/user/model/UserFilters.kt
@@ -7,6 +7,7 @@ import io.newm.server.ktx.newerThan
 import io.newm.server.ktx.olderThan
 import io.newm.server.ktx.roles
 import io.newm.server.ktx.sortOrder
+import io.newm.server.model.FilterCriteria
 import org.jetbrains.exposed.sql.SortOrder
 import java.time.LocalDateTime
 import java.util.UUID
@@ -15,9 +16,9 @@ data class UserFilters(
     val sortOrder: SortOrder?,
     val olderThan: LocalDateTime?,
     val newerThan: LocalDateTime?,
-    val ids: List<UUID>?,
-    val roles: List<String>?,
-    val genres: List<String>?
+    val ids: FilterCriteria<UUID>?,
+    val roles: FilterCriteria<String>?,
+    val genres: FilterCriteria<String>?
 )
 
 val ApplicationCall.userFilters: UserFilters

--- a/newm-server/src/main/kotlin/io/newm/server/ktx/ApplicationCallExt.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/ktx/ApplicationCallExt.kt
@@ -9,13 +9,15 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.bits.Memory
-import io.newm.server.features.marketplace.model.SaleStatus
 import io.newm.server.features.song.model.MintingStatus
+import io.newm.server.model.FilterCriteria
+import io.newm.server.model.toFilterCriteria
+import io.newm.server.model.toStringFilterCriteria
+import io.newm.server.model.toUUIDFilterCriteria
 import io.newm.server.typealiases.SongId
 import io.newm.server.typealiases.UserId
 import io.newm.shared.exception.HttpUnauthorizedException
 import io.newm.shared.ktx.orZero
-import io.newm.shared.ktx.splitAndTrim
 import io.newm.shared.ktx.toHexString
 import io.newm.shared.ktx.toLocalDateTime
 import io.newm.shared.ktx.toUUID
@@ -66,28 +68,28 @@ val ApplicationCall.limit: Int
 val ApplicationCall.sortOrder: SortOrder?
     get() = parameters["sortOrder"]?.let { SortOrder.valueOf(it.uppercase()) }
 
-val ApplicationCall.ids: List<UUID>?
-    get() = parameters["ids"]?.splitAndTrim()?.map(String::toUUID)
+val ApplicationCall.ids: FilterCriteria<UUID>?
+    get() = parameters["ids"]?.toUUIDFilterCriteria()
 
-val ApplicationCall.ownerIds: List<UserId>?
+val ApplicationCall.ownerIds: FilterCriteria<UUID>?
     get() =
-        parameters["ownerIds"]?.splitAndTrim()?.map {
+        parameters["ownerIds"]?.toFilterCriteria {
             if (it == "me") myUserId else it.toUUID()
         }
-val ApplicationCall.songIds: List<SongId>?
-    get() = parameters["songIds"]?.splitAndTrim()?.map(String::toUUID)
+val ApplicationCall.songIds: FilterCriteria<UUID>?
+    get() = parameters["songIds"]?.toUUIDFilterCriteria()
 
-val ApplicationCall.emails: List<String>?
-    get() = parameters["emails"]?.splitAndTrim()
+val ApplicationCall.emails: FilterCriteria<String>?
+    get() = parameters["emails"]?.toStringFilterCriteria()
 
-val ApplicationCall.genres: List<String>?
-    get() = parameters["genres"]?.splitAndTrim()
+val ApplicationCall.genres: FilterCriteria<String>?
+    get() = parameters["genres"]?.toStringFilterCriteria()
 
-val ApplicationCall.moods: List<String>?
-    get() = parameters["moods"]?.splitAndTrim()
+val ApplicationCall.moods: FilterCriteria<String>?
+    get() = parameters["moods"]?.toStringFilterCriteria()
 
-val ApplicationCall.roles: List<String>?
-    get() = parameters["roles"]?.splitAndTrim()
+val ApplicationCall.roles: FilterCriteria<String>?
+    get() = parameters["roles"]?.toStringFilterCriteria()
 
 val ApplicationCall.olderThan: LocalDateTime?
     get() = parameters["olderThan"]?.toLocalDateTime()
@@ -101,23 +103,14 @@ val ApplicationCall.phrase: String?
 val ApplicationCall.archived: Boolean?
     get() = parameters["archived"]?.toBoolean()
 
-val ApplicationCall.mintingStatuses: List<MintingStatus>?
-    get() = parameters["mintingStatuses"]?.splitAndTrim()?.map(MintingStatus::valueOf)
-
-val ApplicationCall.nftNames: List<String>?
-    get() = parameters["nftNames"]?.splitAndTrim()
-
 val ApplicationCall.connectionId: UUID
     get() = parameters["connectionId"]!!.toUUID()
 
 val ApplicationCall.saleId: UUID
     get() = parameters["saleId"]!!.toUUID()
 
-val ApplicationCall.saleStatuses: List<SaleStatus>?
-    get() = parameters["saleStatuses"]?.splitAndTrim()?.map(SaleStatus::valueOf)
-
-val ApplicationCall.artistIds: List<UUID>?
-    get() = parameters["artistIds"]?.splitAndTrim()?.map(String::toUUID)
+val ApplicationCall.artistIds: FilterCriteria<UUID>?
+    get() = parameters["artistIds"]?.toUUIDFilterCriteria()
 
 suspend inline fun ApplicationCall.identifyUser(crossinline body: suspend ApplicationCall.(UUID, Boolean) -> Unit) {
     val uid = userId

--- a/newm-server/src/main/kotlin/io/newm/server/model/FilterCriteria.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/model/FilterCriteria.kt
@@ -1,0 +1,30 @@
+package io.newm.server.model
+
+import io.newm.shared.ktx.splitAndTrim
+import io.newm.shared.ktx.toUUID
+import java.util.UUID
+
+data class FilterCriteria<T>(
+    val includes: List<T>? = null,
+    val excludes: List<T>? = null
+)
+
+fun <T> String.toFilterCriteria(transform: (String) -> T): FilterCriteria<T> {
+    val includes = mutableListOf<T>()
+    val excludes = mutableListOf<T>()
+    for (str in splitAndTrim()) {
+        when {
+            str.startsWith('-') -> excludes += transform(str.substring(1))
+            str.startsWith('+') -> includes += transform(str.substring(1))
+            else -> includes += transform(str)
+        }
+    }
+    return FilterCriteria(
+        includes = includes.takeIf { it.isNotEmpty() },
+        excludes = excludes.takeIf { it.isNotEmpty() }
+    )
+}
+
+fun String.toStringFilterCriteria(): FilterCriteria<String> = toFilterCriteria { it }
+
+fun String.toUUIDFilterCriteria(): FilterCriteria<UUID> = toFilterCriteria(String::toUUID)

--- a/newm-server/src/test/kotlin/io/newm/server/features/collaborations/CollaborationRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/collaborations/CollaborationRoutesTests.kt
@@ -331,6 +331,43 @@ class CollaborationRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetCollaborationsByIdsExclusion() =
+        runBlocking {
+            // Add collaborations directly into database
+            val allCollaborations = mutableListOf<Collaboration>()
+            for (offset in 0..30) {
+                allCollaborations += addCollaborationToDatabase(testUserId, offset)
+            }
+
+            // filter out 1st and last
+            val expectedCollaborations = allCollaborations.subList(1, allCollaborations.size - 1)
+            val ids = allCollaborations.filter { it !in expectedCollaborations }.joinToString { "-${it.id}" }
+
+            // Get all collaborations forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualCollaborations = mutableListOf<Collaboration>()
+            while (true) {
+                val response =
+                    client.get("v1/collaborations") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("ids", ids)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val collaborations = response.body<List<Collaboration>>()
+                if (collaborations.isEmpty()) break
+                actualCollaborations += collaborations
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualCollaborations).isEqualTo(expectedCollaborations)
+        }
+
+    @Test
     fun testGetCollaborationsBySongIds() =
         runBlocking {
             // Add collaborations directly into database
@@ -342,6 +379,43 @@ class CollaborationRoutesTests : BaseApplicationTests() {
             // filter out 1st and last
             val expectedCollaborations = allCollaborations.subList(1, allCollaborations.size - 1)
             val songIds = expectedCollaborations.joinToString { it.songId.toString() }
+
+            // Get all collaborations forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualCollaborations = mutableListOf<Collaboration>()
+            while (true) {
+                val response =
+                    client.get("v1/collaborations") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("songIds", songIds)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val collaborations = response.body<List<Collaboration>>()
+                if (collaborations.isEmpty()) break
+                actualCollaborations += collaborations
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualCollaborations).isEqualTo(expectedCollaborations)
+        }
+
+    @Test
+    fun testGetCollaborationsBySongIdsExclusion() =
+        runBlocking {
+            // Add collaborations directly into database
+            val allCollaborations = mutableListOf<Collaboration>()
+            for (offset in 0..30) {
+                allCollaborations += addCollaborationToDatabase(testUserId, offset)
+            }
+
+            // filter out 1st and last
+            val expectedCollaborations = allCollaborations.subList(1, allCollaborations.size - 1)
+            val songIds = allCollaborations.filter { it !in expectedCollaborations }.joinToString { "-${it.songId}" }
 
             // Get all collaborations forcing pagination
             var offset = 0
@@ -405,6 +479,43 @@ class CollaborationRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetCollaborationsByEmailsExclusion() =
+        runBlocking {
+            // Add collaborations directly into database
+            val allCollaborations = mutableListOf<Collaboration>()
+            for (offset in 0..30) {
+                allCollaborations += addCollaborationToDatabase(testUserId, offset)
+            }
+
+            // filter out 1st and last
+            val expectedCollaborations = allCollaborations.subList(1, allCollaborations.size - 1)
+            val emails = allCollaborations.filter { it !in expectedCollaborations }.joinToString { "-${it.email}" }
+
+            // Get all collaborations forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualCollaborations = mutableListOf<Collaboration>()
+            while (true) {
+                val response =
+                    client.get("v1/collaborations") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("emails", emails)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val collaborations = response.body<List<Collaboration>>()
+                if (collaborations.isEmpty()) break
+                actualCollaborations += collaborations
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualCollaborations).isEqualTo(expectedCollaborations)
+        }
+
+    @Test
     fun testGetCollaborationsByStatuses() =
         runBlocking {
             // Add collaborations directly into database
@@ -429,6 +540,44 @@ class CollaborationRoutesTests : BaseApplicationTests() {
                             parameter("offset", offset)
                             parameter("limit", limit)
                             parameter("statuses", expectedStatus)
+                        }
+                    assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                    val collaborations = response.body<List<Collaboration>>()
+                    if (collaborations.isEmpty()) break
+                    actualCollaborations += collaborations
+                    offset += limit
+                }
+
+                // verify all
+                assertThat(actualCollaborations).isEqualTo(expectedCollaborations)
+            }
+        }
+
+    @Test
+    fun testGetCollaborationsByStatusesExclusion() =
+        runBlocking {
+            // Add collaborations directly into database
+            val allCollaborations = mutableListOf<Collaboration>()
+            for (offset in 0..30) {
+                allCollaborations += addCollaborationToDatabase(testUserId, offset)
+            }
+
+            for (expectedStatus in CollaborationStatus.entries) {
+                // filter out
+                val expectedCollaborations = allCollaborations.filter { it.status != expectedStatus }
+
+                // Get all collaborations forcing pagination
+                var offset = 0
+                val limit = 5
+                val actualCollaborations = mutableListOf<Collaboration>()
+                while (true) {
+                    val response =
+                        client.get("v1/collaborations") {
+                            bearerAuth(testUserToken)
+                            accept(ContentType.Application.Json)
+                            parameter("offset", offset)
+                            parameter("limit", limit)
+                            parameter("statuses", "-$expectedStatus")
                         }
                     assertThat(response.status).isEqualTo(HttpStatusCode.OK)
                     val collaborations = response.body<List<Collaboration>>()
@@ -723,6 +872,63 @@ class CollaborationRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetCollaboratorsBySongIdExclusion() =
+        runBlocking {
+            // Add Collaborations directly into database
+            val allCollaborators = mutableListOf<Collaborator>()
+            val allCollaborations = mutableListOf<Collaboration>()
+            for (offset in 0..30) {
+                val email = "collaborator$offset@email.com"
+                val user =
+                    takeIf { offset % 2 == 0 }?.let {
+                        transaction {
+                            UserEntity.new {
+                                this.email = email
+                            }
+                        }.toModel(false)
+                    }
+                val songCount = (offset % 4) + 1
+                val status = user?.let { CollaborationStatus.Accepted }
+                for (i in 1..songCount) {
+                    allCollaborations += addCollaborationToDatabase(testUserId, i, email, status)
+                }
+                allCollaborators += Collaborator(email, songCount.toLong(), user)
+            }
+
+            // filter out 1st and last
+            val expectedCollaborators = allCollaborators.subList(1, allCollaborators.size - 1)
+            val songIds =
+                allCollaborations.filterNot {
+                    it.email != allCollaborators.first().email && it.email != allCollaborators.last().email
+                }.joinToString { "-${it.songId}" }
+
+            // Get all collaborations forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualCollaborators = mutableListOf<Collaborator>()
+            while (true) {
+                val response =
+                    client.get("v1/collaborations/collaborators") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("songIds", songIds)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val collaborators = response.body<List<Collaborator>>()
+                if (collaborators.isEmpty()) break
+                actualCollaborators += collaborators
+                offset += limit
+            }
+
+            // verify all
+            val actualSorted = actualCollaborators.sortedBy { it.email }
+            val expectedSorted = expectedCollaborators.sortedBy { it.email }
+            assertThat(actualSorted).isEqualTo(expectedSorted)
+        }
+
+    @Test
     fun testGetCollaboratorsByEmails() =
         runBlocking {
             // Add Collaborations directly into database
@@ -752,6 +958,63 @@ class CollaborationRoutesTests : BaseApplicationTests() {
                 allCollaborations.filter {
                     it.email != allCollaborators.first().email && it.email != allCollaborators.last().email
                 }.joinToString { it.email!! }
+
+            // Get all collaborations forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualCollaborators = mutableListOf<Collaborator>()
+            while (true) {
+                val response =
+                    client.get("v1/collaborations/collaborators") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("emails", emails)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val collaborators = response.body<List<Collaborator>>()
+                if (collaborators.isEmpty()) break
+                actualCollaborators += collaborators
+                offset += limit
+            }
+
+            // verify all
+            val actualSorted = actualCollaborators.sortedBy { it.email }
+            val expectedSorted = expectedCollaborators.sortedBy { it.email }
+            assertThat(actualSorted).isEqualTo(expectedSorted)
+        }
+
+    @Test
+    fun testGetCollaboratorsByEmailsExclusion() =
+        runBlocking {
+            // Add Collaborations directly into database
+            val allCollaborators = mutableListOf<Collaborator>()
+            val allCollaborations = mutableListOf<Collaboration>()
+            for (offset in 0..30) {
+                val email = "collaborator$offset@email.com"
+                val user =
+                    takeIf { offset % 2 == 0 }?.let {
+                        transaction {
+                            UserEntity.new {
+                                this.email = email
+                            }
+                        }.toModel(false)
+                    }
+                val songCount = (offset % 4) + 1
+                val status = user?.let { CollaborationStatus.Accepted }
+                for (i in 1..songCount) {
+                    allCollaborations += addCollaborationToDatabase(testUserId, i, email, status)
+                }
+                allCollaborators += Collaborator(email, songCount.toLong(), user)
+            }
+
+            // filter out 1st and last
+            val expectedCollaborators = allCollaborators.subList(1, allCollaborators.size - 1)
+            val emails =
+                allCollaborations.filterNot {
+                    it.email != allCollaborators.first().email && it.email != allCollaborators.last().email
+                }.joinToString { "-${it.email}" }
 
             // Get all collaborations forcing pagination
             var offset = 0

--- a/newm-server/src/test/kotlin/io/newm/server/features/marketplace/MarketplaceRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/marketplace/MarketplaceRoutesTests.kt
@@ -172,6 +172,39 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetSalesByIdExclusion() =
+        runBlocking {
+            val allSales = mutableListOf<Sale>()
+            for (offset in 0..30) {
+                allSales += addSaleToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedSales = allSales.subList(1, allSales.size - 1)
+            val ids = allSales.filter { it !in expectedSales }.joinToString { "-${it.id}" }
+
+            // Get sales forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSales = mutableListOf<Sale>()
+            while (true) {
+                val response =
+                    client.get("v1/marketplace/sales") {
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("ids", ids)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val sales = response.body<List<Sale>>()
+                if (sales.isEmpty()) break
+                actualSales += sales
+                offset += limit
+            }
+            assertThat(actualSales).isEqualTo(expectedSales)
+        }
+
+    @Test
     fun testGetSalesBySongId() =
         runBlocking {
             val allSales = mutableListOf<Sale>()
@@ -205,6 +238,39 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetSalesBySongIdExclusion() =
+        runBlocking {
+            val allSales = mutableListOf<Sale>()
+            for (offset in 0..30) {
+                allSales += addSaleToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedSales = allSales.subList(1, allSales.size - 1)
+            val songIds = allSales.filter { it !in expectedSales }.joinToString { "-${it.song!!.id}" }
+
+            // Get sales forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSales = mutableListOf<Sale>()
+            while (true) {
+                val response =
+                    client.get("v1/marketplace/sales") {
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("songIds", songIds)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val sales = response.body<List<Sale>>()
+                if (sales.isEmpty()) break
+                actualSales += sales
+                offset += limit
+            }
+            assertThat(actualSales).isEqualTo(expectedSales)
+        }
+
+    @Test
     fun testGetSalesByArtistId() =
         runBlocking {
             val allSales = mutableListOf<Sale>()
@@ -215,6 +281,39 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
             // filter out 1st and last
             val expectedSales = allSales.subList(1, allSales.size - 1)
             val artistIds = expectedSales.joinToString { it.song!!.artistId.toString() }
+
+            // Get sales forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSales = mutableListOf<Sale>()
+            while (true) {
+                val response =
+                    client.get("v1/marketplace/sales") {
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("artistIds", artistIds)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val sales = response.body<List<Sale>>()
+                if (sales.isEmpty()) break
+                actualSales += sales
+                offset += limit
+            }
+            assertThat(actualSales).isEqualTo(expectedSales)
+        }
+
+    @Test
+    fun testGetSalesByArtistIdExclusion() =
+        runBlocking {
+            val allSales = mutableListOf<Sale>()
+            for (offset in 0..30) {
+                allSales += addSaleToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedSales = allSales.subList(1, allSales.size - 1)
+            val artistIds = allSales.filter { it !in expectedSales }.joinToString { "-${it.song!!.artistId}" }
 
             // Get sales forcing pagination
             var offset = 0
@@ -272,6 +371,40 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetSalesByStatusExclusion() =
+        runBlocking {
+            val allSales = mutableListOf<Sale>()
+            for (offset in 0..30) {
+                allSales += addSaleToDatabase(offset)
+            }
+
+            for (expectedSaleStatus in SaleStatus.entries) {
+                // filter out
+                val expectedSales = allSales.filter { it.status != expectedSaleStatus }
+
+                // Get sales forcing pagination
+                var offset = 0
+                val limit = 5
+                val actualSales = mutableListOf<Sale>()
+                while (true) {
+                    val response =
+                        client.get("v1/marketplace/sales") {
+                            accept(ContentType.Application.Json)
+                            parameter("offset", offset)
+                            parameter("limit", limit)
+                            parameter("saleStatuses", "-$expectedSaleStatus")
+                        }
+                    assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                    val sales = response.body<List<Sale>>()
+                    if (sales.isEmpty()) break
+                    actualSales += sales
+                    offset += limit
+                }
+                assertThat(actualSales).isEqualTo(expectedSales)
+            }
+        }
+
+    @Test
     fun testGetSalesByGenres() =
         runBlocking {
             val allSales = mutableListOf<Sale>()
@@ -305,6 +438,39 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetSalesByGenresExclusion() =
+        runBlocking {
+            val allSales = mutableListOf<Sale>()
+            for (offset in 0..30) {
+                allSales += addSaleToDatabase(offset)
+            }
+
+            // filter out 1st and last and take only 1st genre of each
+            val expectedSales = allSales.subList(1, allSales.size - 1)
+            val genres = allSales.filter { it !in expectedSales }.joinToString { "-${it.song!!.genres!!.first()}" }
+
+            // Get sales forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSales = mutableListOf<Sale>()
+            while (true) {
+                val response =
+                    client.get("v1/marketplace/sales") {
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("genres", genres)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val sales = response.body<List<Sale>>()
+                if (sales.isEmpty()) break
+                actualSales += sales
+                offset += limit
+            }
+            assertThat(actualSales).isEqualTo(expectedSales)
+        }
+
+    @Test
     fun testGetSalesByMoods() =
         runBlocking {
             val allSales = mutableListOf<Sale>()
@@ -315,6 +481,39 @@ class MarketplaceRoutesTests : BaseApplicationTests() {
             // filter out 1st and last and take only 1st mood of each
             val expectedSales = allSales.subList(1, allSales.size - 1)
             val moods = expectedSales.joinToString { it.song?.moods!!.first() }
+
+            // Get sales forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSales = mutableListOf<Sale>()
+            while (true) {
+                val response =
+                    client.get("v1/marketplace/sales") {
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("moods", moods)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val sales = response.body<List<Sale>>()
+                if (sales.isEmpty()) break
+                actualSales += sales
+                offset += limit
+            }
+            assertThat(actualSales).isEqualTo(expectedSales)
+        }
+
+    @Test
+    fun testGetSalesByMoodsExclusion() =
+        runBlocking {
+            val allSales = mutableListOf<Sale>()
+            for (offset in 0..30) {
+                allSales += addSaleToDatabase(offset)
+            }
+
+            // filter out 1st and last and take only 1st mood of each
+            val expectedSales = allSales.subList(1, allSales.size - 1)
+            val moods = allSales.filter { it !in expectedSales }.joinToString { "-${it.song!!.moods!!.first()}" }
 
             // Get sales forcing pagination
             var offset = 0

--- a/newm-server/src/test/kotlin/io/newm/server/features/minting/repo/MintingRepositoryTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/minting/repo/MintingRepositoryTest.kt
@@ -27,6 +27,7 @@ import io.newm.server.features.song.repo.SongRepositoryImpl
 import io.newm.server.features.user.database.UserEntity
 import io.newm.server.features.user.database.UserTable
 import io.newm.server.features.user.model.User
+import io.newm.server.model.FilterCriteria
 import io.newm.server.typealiases.SongId
 import io.newm.shared.ktx.toHexString
 import io.newm.txbuilder.ktx.toCborObject
@@ -38,7 +39,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 class MintingRepositoryTest : BaseApplicationTests() {
     @BeforeEach
@@ -317,18 +318,19 @@ class MintingRepositoryTest : BaseApplicationTests() {
                     primaryArtist.id!!,
                     CollaborationFilters(
                         inbound = null,
-                        songIds = listOf(song.id!!),
+                        songIds = FilterCriteria(includes = listOf(song.id!!)),
                         olderThan = null,
                         newerThan = null,
                         ids = null,
-                        statuses = listOf(CollaborationStatus.Accepted),
+                        statuses = FilterCriteria(includes = listOf(CollaborationStatus.Accepted)),
                     ),
                     0,
                     Integer.MAX_VALUE
                 )
 
             val plutusDataHex =
-                mintingRepository.buildStreamTokenMetadata(release, song, primaryArtist, collabs).toCborObject().toCborByteArray()
+                mintingRepository.buildStreamTokenMetadata(release, song, primaryArtist, collabs).toCborObject()
+                    .toCborByteArray()
                     .toHexString()
 
             println("plutusDataHex: $plutusDataHex")
@@ -398,11 +400,11 @@ class MintingRepositoryTest : BaseApplicationTests() {
                     primaryArtist.id!!,
                     CollaborationFilters(
                         inbound = null,
-                        songIds = listOf(song.id!!),
+                        songIds = FilterCriteria(includes = listOf(song.id!!)),
                         olderThan = null,
                         newerThan = null,
                         ids = null,
-                        statuses = listOf(CollaborationStatus.Accepted),
+                        statuses = FilterCriteria(includes = listOf(CollaborationStatus.Accepted)),
                     ),
                     0,
                     Integer.MAX_VALUE
@@ -500,7 +502,13 @@ class MintingRepositoryTest : BaseApplicationTests() {
                     cip68Policy = "a0488f6ef1b8b5b268583312a94aaebefb36e570b198e02024d321a9",
                     refTokenName = refTokenName,
                     fracTokenName = fracTokenName,
-                    streamTokenSplits = listOf(Pair("addr_test1vz0pdhl9yagp6mk4ncqvgxx796sl4hxarfazy88s63xtdscuqxqf5", 100000000L)),
+                    streamTokenSplits =
+                        listOf(
+                            Pair(
+                                "addr_test1vz0pdhl9yagp6mk4ncqvgxx796sl4hxarfazy88s63xtdscuqxqf5",
+                                100000000L
+                            )
+                        ),
                     requiredSigners = signingKeys,
                     starterTokenUtxoReference = starterTokenUtxoReference,
                     mintScriptUtxoReference = mintScriptUtxoReference,
@@ -535,7 +543,13 @@ class MintingRepositoryTest : BaseApplicationTests() {
                     cip68Policy = "a0488f6ef1b8b5b268583312a94aaebefb36e570b198e02024d321a9",
                     refTokenName = refTokenName,
                     fracTokenName = fracTokenName,
-                    streamTokenSplits = listOf(Pair("addr_test1vz0pdhl9yagp6mk4ncqvgxx796sl4hxarfazy88s63xtdscuqxqf5", 100000000L)),
+                    streamTokenSplits =
+                        listOf(
+                            Pair(
+                                "addr_test1vz0pdhl9yagp6mk4ncqvgxx796sl4hxarfazy88s63xtdscuqxqf5",
+                                100000000L
+                            )
+                        ),
                     requiredSigners = signingKeys,
                     starterTokenUtxoReference = starterTokenUtxoReference,
                     mintScriptUtxoReference = mintScriptUtxoReference,

--- a/newm-server/src/test/kotlin/io/newm/server/features/song/SongRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/song/SongRoutesTests.kt
@@ -344,6 +344,43 @@ class SongRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetSongsByIdsExclusion() =
+        runBlocking {
+            // Add Songs directly into database
+            val allSongs = mutableListOf<Song>()
+            for (offset in 0..30) {
+                allSongs += addSongToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedSongs = allSongs.subList(1, allSongs.size - 1)
+            val ids = allSongs.filter { it !in expectedSongs }.joinToString { "-${it.id}" }
+
+            // Get all songs forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSongs = mutableListOf<Song>()
+            while (true) {
+                val response =
+                    client.get("v1/songs") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("ids", ids)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val songs = response.body<List<Song>>()
+                if (songs.isEmpty()) break
+                actualSongs += songs
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualSongs).isEqualTo(expectedSongs)
+        }
+
+    @Test
     fun testGetSongsByOwnerIds() =
         runBlocking {
             // Add Songs directly into database
@@ -355,6 +392,43 @@ class SongRoutesTests : BaseApplicationTests() {
             // filter out 1st and last
             val expectedSongs = allSongs.subList(1, allSongs.size - 1)
             val ownerIds = expectedSongs.joinToString { it.ownerId.toString() }
+
+            // Get all songs forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSongs = mutableListOf<Song>()
+            while (true) {
+                val response =
+                    client.get("v1/songs") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("ownerIds", ownerIds)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val songs = response.body<List<Song>>()
+                if (songs.isEmpty()) break
+                actualSongs += songs
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualSongs).isEqualTo(expectedSongs)
+        }
+
+    @Test
+    fun testGetSongsByOwnerIdsExclusion() =
+        runBlocking {
+            // Add Songs directly into database
+            val allSongs = mutableListOf<Song>()
+            for (offset in 0..30) {
+                allSongs += addSongToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedSongs = allSongs.subList(1, allSongs.size - 1)
+            val ownerIds = allSongs.filter { it !in expectedSongs }.joinToString { "-${it.ownerId}" }
 
             // Get all songs forcing pagination
             var offset = 0
@@ -418,6 +492,43 @@ class SongRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetSongsByGenresExclusion() =
+        runBlocking {
+            // Add Songs directly into database
+            val allSongs = mutableListOf<Song>()
+            for (offset in 0..30) {
+                allSongs += addSongToDatabase(offset)
+            }
+
+            // filter out 1st and last and take only 1st genre of each
+            val expectedSongs = allSongs.subList(1, allSongs.size - 1)
+            val genres = allSongs.filter { it !in expectedSongs }.joinToString { "-${it.genres!!.first()}" }
+
+            // Get all songs forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSongs = mutableListOf<Song>()
+            while (true) {
+                val response =
+                    client.get("v1/songs") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("genres", genres)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val songs = response.body<List<Song>>()
+                if (songs.isEmpty()) break
+                actualSongs += songs
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualSongs).isEqualTo(expectedSongs)
+        }
+
+    @Test
     fun testGetSongsByMoods() =
         runBlocking {
             // Add Songs directly into database
@@ -429,6 +540,43 @@ class SongRoutesTests : BaseApplicationTests() {
             // filter out 1st and last and take only 1st mood of each
             val expectedSongs = allSongs.subList(1, allSongs.size - 1)
             val moods = expectedSongs.joinToString { it.moods!!.first() }
+
+            // Get all songs forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualSongs = mutableListOf<Song>()
+            while (true) {
+                val response =
+                    client.get("v1/songs") {
+                        bearerAuth(testUserToken)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("moods", moods)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val songs = response.body<List<Song>>()
+                if (songs.isEmpty()) break
+                actualSongs += songs
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualSongs).isEqualTo(expectedSongs)
+        }
+
+    @Test
+    fun testGetSongsByMoodsExclusion() =
+        runBlocking {
+            // Add Songs directly into database
+            val allSongs = mutableListOf<Song>()
+            for (offset in 0..30) {
+                allSongs += addSongToDatabase(offset)
+            }
+
+            // filter out 1st and last and take only 1st mood of each
+            val expectedSongs = allSongs.subList(1, allSongs.size - 1)
+            val moods = allSongs.filter { it !in expectedSongs }.joinToString { "-${it.moods!!.first()}" }
 
             // Get all songs forcing pagination
             var offset = 0
@@ -479,6 +627,44 @@ class SongRoutesTests : BaseApplicationTests() {
                             parameter("offset", offset)
                             parameter("limit", limit)
                             parameter("mintingStatuses", expectedMintingStatus)
+                        }
+                    assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                    val songs = response.body<List<Song>>()
+                    if (songs.isEmpty()) break
+                    actualSongs += songs
+                    offset += limit
+                }
+
+                // verify all
+                assertThat(actualSongs).isEqualTo(expectedSongs)
+            }
+        }
+
+    @Test
+    fun testGetSongsByMintingStatusExclusion() =
+        runBlocking {
+            // Add Songs directly into database
+            val allSongs = mutableListOf<Song>()
+            for (offset in 0..30) {
+                allSongs += addSongToDatabase(offset)
+            }
+
+            for (expectedMintingStatus in MintingStatus.entries) {
+                // filter out
+                val expectedSongs = allSongs.filter { it.mintingStatus != expectedMintingStatus }
+
+                // Get all songs forcing pagination
+                var offset = 0
+                val limit = 5
+                val actualSongs = mutableListOf<Song>()
+                while (true) {
+                    val response =
+                        client.get("v1/songs") {
+                            bearerAuth(testUserToken)
+                            accept(ContentType.Application.Json)
+                            parameter("offset", offset)
+                            parameter("limit", limit)
+                            parameter("mintingStatuses", "-$expectedMintingStatus")
                         }
                     assertThat(response.status).isEqualTo(HttpStatusCode.OK)
                     val songs = response.body<List<Song>>()

--- a/newm-server/src/test/kotlin/io/newm/server/features/user/UserRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/user/UserRoutesTests.kt
@@ -523,6 +523,69 @@ class UserRoutesTests : BaseApplicationTests() {
         }
 
     @Test
+    fun testGetUsersByIdsExclusion() =
+        runBlocking {
+            // Put Users directly into database
+            val allUsers = mutableListOf<User>()
+            for (offset in 0..30) {
+                allUsers += addUserToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedUsers = allUsers.subList(1, allUsers.size - 1)
+            val ids = allUsers.filter { it !in expectedUsers }.joinToString { "-${it.id}" }
+
+            // read back all Users forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualUsers = mutableListOf<User>()
+            val token = expectedUsers.first().id.toString()
+            while (true) {
+                val response =
+                    client.get("v1/users") {
+                        bearerAuth(token)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("ids", ids)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val users = response.body<List<User>>()
+                if (users.isEmpty()) break
+                actualUsers += users
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualUsers.size).isEqualTo(expectedUsers.size)
+            expectedUsers.forEachIndexed { i, expectedUser ->
+                val actualUser = actualUsers[i]
+                assertThat(actualUser.id).isEqualTo(expectedUser.id)
+                assertThat(actualUser.firstName).isEqualTo(expectedUser.firstName)
+                assertThat(actualUser.lastName).isEqualTo(expectedUser.lastName)
+                assertThat(actualUser.nickname).isEqualTo(expectedUser.nickname)
+                assertThat(actualUser.pictureUrl).isEqualTo(expectedUser.pictureUrl)
+                assertThat(actualUser.bannerUrl).isEqualTo(expectedUser.bannerUrl)
+                assertThat(actualUser.websiteUrl).isEqualTo(expectedUser.websiteUrl)
+                assertThat(actualUser.twitterUrl).isEqualTo(expectedUser.twitterUrl)
+                assertThat(actualUser.instagramUrl).isEqualTo(expectedUser.instagramUrl)
+                assertThat(actualUser.spotifyProfile).isEqualTo(expectedUser.spotifyProfile)
+                assertThat(actualUser.soundCloudProfile).isEqualTo(expectedUser.soundCloudProfile)
+                assertThat(actualUser.appleMusicProfile).isEqualTo(expectedUser.appleMusicProfile)
+                assertThat(actualUser.location).isEqualTo(expectedUser.location)
+                assertThat(actualUser.role).isEqualTo(expectedUser.role)
+                assertThat(actualUser.genre).isEqualTo(expectedUser.genre)
+                assertThat(actualUser.biography).isEqualTo(expectedUser.biography)
+                assertThat(actualUser.isni).isEqualTo(expectedUser.isni)
+                assertThat(actualUser.ipi).isEqualTo(expectedUser.ipi)
+                assertThat(actualUser.companyName).isEqualTo(expectedUser.companyName)
+                assertThat(actualUser.companyLogoUrl).isEqualTo(expectedUser.companyLogoUrl)
+                assertThat(actualUser.companyIpRights).isEqualTo(expectedUser.companyIpRights)
+                assertThat(actualUser.dspPlanSubscribed).isEqualTo(expectedUser.dspPlanSubscribed)
+            }
+        }
+
+    @Test
     fun testGetUsersByRoles() =
         runBlocking {
             // Put Users directly into database
@@ -611,6 +674,132 @@ class UserRoutesTests : BaseApplicationTests() {
                         parameter("offset", offset)
                         parameter("limit", limit)
                         parameter("genres", genres)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val users = response.body<List<User>>()
+                if (users.isEmpty()) break
+                actualUsers += users
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualUsers.size).isEqualTo(expectedUsers.size)
+            expectedUsers.forEachIndexed { i, expectedUser ->
+                val actualUser = actualUsers[i]
+                assertThat(actualUser.id).isEqualTo(expectedUser.id)
+                assertThat(actualUser.firstName).isEqualTo(expectedUser.firstName)
+                assertThat(actualUser.lastName).isEqualTo(expectedUser.lastName)
+                assertThat(actualUser.nickname).isEqualTo(expectedUser.nickname)
+                assertThat(actualUser.pictureUrl).isEqualTo(expectedUser.pictureUrl)
+                assertThat(actualUser.bannerUrl).isEqualTo(expectedUser.bannerUrl)
+                assertThat(actualUser.websiteUrl).isEqualTo(expectedUser.websiteUrl)
+                assertThat(actualUser.twitterUrl).isEqualTo(expectedUser.twitterUrl)
+                assertThat(actualUser.instagramUrl).isEqualTo(expectedUser.instagramUrl)
+                assertThat(actualUser.spotifyProfile).isEqualTo(expectedUser.spotifyProfile)
+                assertThat(actualUser.soundCloudProfile).isEqualTo(expectedUser.soundCloudProfile)
+                assertThat(actualUser.appleMusicProfile).isEqualTo(expectedUser.appleMusicProfile)
+                assertThat(actualUser.location).isEqualTo(expectedUser.location)
+                assertThat(actualUser.role).isEqualTo(expectedUser.role)
+                assertThat(actualUser.genre).isEqualTo(expectedUser.genre)
+                assertThat(actualUser.biography).isEqualTo(expectedUser.biography)
+                assertThat(actualUser.isni).isEqualTo(expectedUser.isni)
+                assertThat(actualUser.ipi).isEqualTo(expectedUser.ipi)
+                assertThat(actualUser.companyName).isEqualTo(expectedUser.companyName)
+                assertThat(actualUser.companyLogoUrl).isEqualTo(expectedUser.companyLogoUrl)
+                assertThat(actualUser.companyIpRights).isEqualTo(expectedUser.companyIpRights)
+                assertThat(actualUser.dspPlanSubscribed).isEqualTo(expectedUser.dspPlanSubscribed)
+            }
+        }
+
+    @Test
+    fun testGetUsersByGenresExclusion() =
+        runBlocking {
+            // Put Users directly into database
+            val allUsers = mutableListOf<User>()
+            for (offset in 0..30) {
+                allUsers += addUserToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedUsers = allUsers.subList(1, allUsers.size - 1)
+            val genres = allUsers.filter { it !in expectedUsers }.joinToString { "-${it.genre}" }
+
+            // read back all Users forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualUsers = mutableListOf<User>()
+            val token = expectedUsers.first().id.toString()
+            while (true) {
+                val response =
+                    client.get("v1/users") {
+                        bearerAuth(token)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("genres", genres)
+                    }
+                assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+                val users = response.body<List<User>>()
+                if (users.isEmpty()) break
+                actualUsers += users
+                offset += limit
+            }
+
+            // verify all
+            assertThat(actualUsers.size).isEqualTo(expectedUsers.size)
+            expectedUsers.forEachIndexed { i, expectedUser ->
+                val actualUser = actualUsers[i]
+                assertThat(actualUser.id).isEqualTo(expectedUser.id)
+                assertThat(actualUser.firstName).isEqualTo(expectedUser.firstName)
+                assertThat(actualUser.lastName).isEqualTo(expectedUser.lastName)
+                assertThat(actualUser.nickname).isEqualTo(expectedUser.nickname)
+                assertThat(actualUser.pictureUrl).isEqualTo(expectedUser.pictureUrl)
+                assertThat(actualUser.bannerUrl).isEqualTo(expectedUser.bannerUrl)
+                assertThat(actualUser.websiteUrl).isEqualTo(expectedUser.websiteUrl)
+                assertThat(actualUser.twitterUrl).isEqualTo(expectedUser.twitterUrl)
+                assertThat(actualUser.instagramUrl).isEqualTo(expectedUser.instagramUrl)
+                assertThat(actualUser.spotifyProfile).isEqualTo(expectedUser.spotifyProfile)
+                assertThat(actualUser.soundCloudProfile).isEqualTo(expectedUser.soundCloudProfile)
+                assertThat(actualUser.appleMusicProfile).isEqualTo(expectedUser.appleMusicProfile)
+                assertThat(actualUser.location).isEqualTo(expectedUser.location)
+                assertThat(actualUser.role).isEqualTo(expectedUser.role)
+                assertThat(actualUser.genre).isEqualTo(expectedUser.genre)
+                assertThat(actualUser.biography).isEqualTo(expectedUser.biography)
+                assertThat(actualUser.isni).isEqualTo(expectedUser.isni)
+                assertThat(actualUser.ipi).isEqualTo(expectedUser.ipi)
+                assertThat(actualUser.companyName).isEqualTo(expectedUser.companyName)
+                assertThat(actualUser.companyLogoUrl).isEqualTo(expectedUser.companyLogoUrl)
+                assertThat(actualUser.companyIpRights).isEqualTo(expectedUser.companyIpRights)
+                assertThat(actualUser.dspPlanSubscribed).isEqualTo(expectedUser.dspPlanSubscribed)
+            }
+        }
+
+    @Test
+    fun testGetUsersByRolesExclusion() =
+        runBlocking {
+            // Put Users directly into database
+            val allUsers = mutableListOf<User>()
+            for (offset in 0..30) {
+                allUsers += addUserToDatabase(offset)
+            }
+
+            // filter out 1st and last
+            val expectedUsers = allUsers.subList(1, allUsers.size - 1)
+            val roles = allUsers.filter { it !in expectedUsers }.joinToString { "-${it.role}" }
+
+            // read back all Users forcing pagination
+            var offset = 0
+            val limit = 5
+            val actualUsers = mutableListOf<User>()
+            val token = expectedUsers.first().id.toString()
+            while (true) {
+                val response =
+                    client.get("v1/users") {
+                        bearerAuth(token)
+                        accept(ContentType.Application.Json)
+                        parameter("offset", offset)
+                        parameter("limit", limit)
+                        parameter("roles", roles)
                     }
                 assertThat(response.status).isEqualTo(HttpStatusCode.OK)
                 val users = response.body<List<User>>()

--- a/newm-shared/src/main/kotlin/io/newm/shared/exposed/ExposedArrays.kt
+++ b/newm-shared/src/main/kotlin/io/newm/shared/exposed/ExposedArrays.kt
@@ -163,6 +163,12 @@ infix fun <T> ExpressionWithColumnType<Array<T>>.overlaps(array: Array<T>): Op<B
 @JvmName("overlaps2")
 infix fun <T> ExpressionWithColumnType<Array<T>?>.overlaps(array: Array<T>): Op<Boolean> = arrayOp(array, "&&")
 
+@JvmName("notOverlaps")
+infix fun <T> ExpressionWithColumnType<Array<T>>.notOverlaps(array: Array<T>): Op<Boolean> = NotOp(overlaps(array))
+
+@JvmName("notOverlaps2")
+infix fun <T> ExpressionWithColumnType<Array<T>?>.notOverlaps(array: Array<T>): Op<Boolean> = NotOp(overlaps(array))
+
 private fun <A, E> ExpressionWithColumnType<A>.arrayOp(
     array: Array<E>,
     opSign: String


### PR DESCRIPTION
Currently, we only need exclusion on the GetSales API filters,  but I added it to all API's for consistency. The way it works is that the caller simply adds a `-` prefix to every filter param value that should be used for exclusion or `+` for inclusion. For backward compatibility, if no prefix is found,  it defaults to inclusion.