### PR TITLE
Artists unable to delete Undistributed tracks in Library after failing to pay.

### DIFF
--- a/newm-server/build.gradle.kts
+++ b/newm-server/build.gradle.kts
@@ -114,7 +114,6 @@ dependencies {
     implementation(Dependencies.JSoup.ALL)
     implementation(Dependencies.QRCodeKotlin.ALL)
     implementation(Dependencies.ApacheCurators.RECEIPES)
-
     implementation(Dependencies.KotlinLogging.ALL)
 
     testImplementation(Dependencies.Ktor.CLIENT_LOGGING)

--- a/newm-server/src/main/kotlin/io/newm/server/features/cardano/parser/NFTSongParser.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/cardano/parser/NFTSongParser.kt
@@ -13,7 +13,6 @@ import io.newm.txbuilder.ktx.fingerprint
 import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
-
 private val nftCdnRepository: NftCdnRepository by inject()
 
 // Used to remove numeric prefixes on legacy SickCity NFT fields ( e.g., "1. Artist Name" and "02. Song Title")


### PR DESCRIPTION
Context/Current State:
An artist had previously uploaded a track, but payment failed during the distribution and minting process. After the distribution errored out, the track was displayed in the Library with an Undistributed status; however, the artist was unable to edit details and/or delete the track. Afterward, each time the tried to re-upload/re-create a different track using the same audio file and title, a 409 error rendered, indicating a conflict with an existing song (because it had the same name as the one that couldn’t be deleted).

Acceptance Criteria/Desired State:

Any song that is in the “Undistributed” status in the Library, should be editable AND able to be deleted.