### PR TITLE
minor: STUD-239Add db column to capture release pre-save links page

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V58__ReleasesUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V58__ReleasesUpdates.kt
@@ -1,0 +1,18 @@
+package io.newm.server.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class V58__ReleasesUpdates : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            exec(
+                """
+                ALTER TABLE releases
+                    ADD COLUMN IF NOT EXISTS pre_save_page text
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
@@ -3,6 +3,7 @@ package io.newm.server.features.distribution.eveara
 import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.AmazonS3
 import com.github.benmanes.caffeine.cache.Caffeine
+import io.newm.chain.util.toB64String
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
@@ -1935,7 +1936,8 @@ class EvearaDistributionRepositoryImpl(
                 Release(
                     distributionReleaseId = response.releaseId,
                     barcodeNumber = barcode,
-                    barcodeType = barcodeType
+                    barcodeType = barcodeType,
+                    preSavePage = response.releaseId.toString().toByteArray().toB64String()
                 )
             )
         } else {

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseEntity.kt
@@ -37,6 +37,7 @@ class ReleaseEntity(id: EntityID<ReleaseId>) : UUIDEntity(id) {
     var hasSubmittedForDistribution: Boolean by ReleaseTable.hasSubmittedForDistribution
     var errorMessage: String? by ReleaseTable.errorMessage
     var forceDistributed: Boolean? by ReleaseTable.forceDistributed
+    var preSavePage: String? by ReleaseTable.preSavePage
 
     fun toModel(): Release =
         Release(
@@ -56,6 +57,7 @@ class ReleaseEntity(id: EntityID<ReleaseId>) : UUIDEntity(id) {
             hasSubmittedForDistribution = hasSubmittedForDistribution,
             errorMessage = errorMessage,
             forceDistributed = forceDistributed,
+            preSavePage = preSavePage
         )
 
     companion object : UUIDEntityClass<ReleaseEntity>(ReleaseTable) {

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/database/ReleaseTable.kt
@@ -36,4 +36,5 @@ object ReleaseTable : UUIDTable(name = "releases") {
     val hasSubmittedForDistribution: Column<Boolean> = bool("has_submitted_for_distribution").default(false)
     val errorMessage: Column<String?> = text("error_message").nullable()
     val forceDistributed: Column<Boolean?> = bool("force_distributed").nullable()
+    val preSavePage: Column<String?> = text("pre_save_page").nullable()
 }

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/model/Release.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/model/Release.kt
@@ -36,6 +36,7 @@ data class Release(
     @Transient
     val forceDistributed: Boolean? = null,
     val errorMessage: String? = null,
+    val preSavePage: String? = null,
 ) {
     @Transient
     val releaseProductCodeType: String =

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
@@ -245,6 +245,7 @@ internal class SongRepositoryImpl(
                 releaseDate?.let { releaseEntity.releaseDate = it }
                 publicationDate?.let { releaseEntity.publicationDate = it }
                 releaseType?.let { releaseEntity.releaseType = it }
+                preSavePage?.let { releaseEntity.preSavePage = it }
 
                 if (requesterId == null) {
                     // don't allow updating these fields when invoked from REST API


### PR DESCRIPTION
Take the eveara release id and base64 encode it. 
For the purposes of this ticket’s acceptance criteria: 
Add a new db column to the releases table to store this information.
 Then calculate it and save it to the db.