### PR TITLE
fix: STUD-224 mark users as archived in case of having released songs…

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V62__UsersUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V62__UsersUpdates.kt
@@ -1,0 +1,19 @@
+package io.newm.server.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("unused")
+class V62__UsersUpdates : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            exec(
+                """
+                ALTER TABLE users
+                    ADD COLUMN IF NOT EXISTS archived BOOLEAN NOT NULL DEFAULT false
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/user/database/UserTable.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/user/database/UserTable.kt
@@ -48,4 +48,5 @@ object UserTable : UUIDTable(name = "users") {
     val distributionIsni: Column<String?> = text("distribution_isni").nullable()
     val distributionIpn: Column<String?> = text("distribution_ipn").nullable()
     val distributionNewmParticipantId: Column<Long?> = long("distribution_newm_participant_id").nullable()
+    val archived: Column<Boolean> = bool("archived").default(false)
 }

--- a/newm-server/src/main/kotlin/io/newm/server/features/user/repo/UserRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/user/repo/UserRepositoryImpl.kt
@@ -342,6 +342,8 @@ internal class UserRepositoryImpl(
             JwtTable.deleteWhere { JwtTable.userId eq userId }
             UserEntity[userId].delete()
         }
+        //TODO: can we catch exception in here in case of users having released songs
+        // and mark them as archived ????
     }
 
     private fun getUserEntityByEmail(email: String): UserEntity =


### PR DESCRIPTION
We don’t want to delete a user if they have released songs because songs are already in blockchain 
We can add a column and mark them as archived  Or user id can pr-fixed to be marked as deleted 
Check with @Walter Lara  what would be the best approach in this scenario 