### PR TITLE
minor: STUD-274 added indexes to user and songs table to enhance query performance 

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/database/migration/V62__UserSongUpdates.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/database/migration/V62__UserSongUpdates.kt
@@ -1,0 +1,23 @@
+package io.newm.server.database.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("unused")
+class V62__UserSongUpdates : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        transaction {
+            execInBatch(
+                listOf(
+                    "CREATE INDEX IF NOT EXISTS songs_title_index ON songs(title)",
+                    "CREATE INDEX IF NOT EXISTS songs_description_index ON songs(description)",
+                    "CREATE INDEX IF NOT EXISTS songs_nft_name_index ON songs(nftName)",
+                    "CREATE INDEX IF NOT EXISTS users_nickname_index ON users(nickname)",
+                    "CREATE INDEX IF NOT EXISTS users_first_name_index ON users(first_name)",
+                    "CREATE INDEX IF NOT EXISTS users_last_name_index ON users(last_name)",
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
Added indexes to user and songs table to enhance query performance.
We already have an index for ownerId and createdAt in place.
But phrase might be a potential candidate to take a close look at since it’s used in the UI query:


![image](https://github.com/projectNEWM/newm-server/assets/14129154/800b3e66-7c61-47f5-a91d-aa41d543d2bd)

![image](https://github.com/projectNEWM/newm-server/assets/14129154/af02c433-d1e0-42ee-a424-31df7824c412)

![image](https://github.com/projectNEWM/newm-server/assets/14129154/ddc68076-e6b7-432b-970c-46aad8928915)

![image](https://github.com/projectNEWM/newm-server/assets/14129154/ffd2c040-2517-4560-adf8-5480f3f0ac9b)

