### PR TITLE
minor: STUD-100 changes should be pushed to Eveara even outside of distribution and minting 

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/DistributionRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/DistributionRepository.kt
@@ -158,4 +158,8 @@ interface DistributionRepository {
     suspend fun getPayoutHistory(userId: UserId): GetPayoutHistoryResponse
 
     suspend fun initiatePayout(userId: UserId): InitiatePayoutResponse
+
+    suspend fun createDistributionUserIfNeeded(user: User)
+
+    suspend fun createDistributionSubscription(user: User)
 }

--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
@@ -1448,7 +1448,7 @@ class EvearaDistributionRepositoryImpl(
         return initiatePayoutResponse
     }
 
-    private suspend fun createDistributionUserIfNeeded(user: User) {
+    override suspend fun createDistributionUserIfNeeded(user: User) {
         // Create the distribution user if they don't yet exist
         val getUserResponse = getUser(user)
         if (getUserResponse.totalRecords > 0) {
@@ -1751,7 +1751,7 @@ class EvearaDistributionRepositoryImpl(
         }
     }
 
-    private suspend fun createDistributionSubscription(user: User) {
+    override suspend fun createDistributionSubscription(user: User) {
         val getSubscriptionResponse = getUserSubscription(user)
         if (getSubscriptionResponse.totalRecords > 0) {
             val existingSubscription = getSubscriptionResponse.subscriptions.first()

--- a/newm-server/src/test/kotlin/io/newm/server/features/user/UserRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/user/UserRoutesTests.kt
@@ -24,6 +24,7 @@ import io.newm.server.config.database.ConfigEntity
 import io.newm.server.config.database.ConfigTable
 import io.newm.server.config.repo.ConfigRepository
 import io.newm.server.config.repo.ConfigRepository.Companion.CONFIG_KEY_EMAIL_WHITELIST
+import io.newm.server.features.distribution.DistributionRepository
 import io.newm.server.features.email.repo.EmailRepositoryImpl
 import io.newm.server.features.model.CountResponse
 import io.newm.server.features.user.database.UserEntity
@@ -60,6 +61,10 @@ class UserRoutesTests : BaseApplicationTests() {
                 }
             }
             single { mockk<EmailRepositoryImpl>(relaxed = true) {} }
+            single {
+                mockk<DistributionRepository>(relaxed = true) {
+                }
+            }
         }
         loadKoinModules(module)
     }


### PR DESCRIPTION
In UserRoutes patch, we update the user in the userRepository database.

We also want to call both of these methods in EvearaDistributionRepositoryImpl after updating the user.

createDistributionUserIfNeeded(user)
createDistributionSubscription(user)

They might be private so you might have to add them to the DistributionRepository interface and make the methods public/override in the Impl class.

This ensures that if a user does something like update their name or their email address, the correct information is sync’d to eveara as well.