### PR TITLE
STUD-325: Create Earnings fee transaction

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/ClaimOrderEntity.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/database/ClaimOrderEntity.kt
@@ -33,7 +33,8 @@ class ClaimOrderEntity(
             failedEarningsIds = failedEarningsIds?.toList(),
             transactionId = transactionId,
             createdAt = createdAt,
-            errorMessage = errorMessage
+            errorMessage = errorMessage,
+            cborHex = "",
         )
 
     companion object : UUIDEntityClass<ClaimOrderEntity>(ClaimOrdersTable)

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrder.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrder.kt
@@ -26,7 +26,8 @@ data class ClaimOrder(
     val transactionId: String?,
     @Contextual
     val createdAt: LocalDateTime,
-    val errorMessage: String?
+    val errorMessage: String?,
+    val cborHex: String,
 ) {
     companion object {
         val ACTIVE_STATUSES = listOf(ClaimOrderStatus.Pending, ClaimOrderStatus.Processing).map { it.name }

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrderRequest.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/ClaimOrderRequest.kt
@@ -1,0 +1,14 @@
+package io.newm.server.features.earnings.model
+
+import io.newm.chain.grpc.Utxo
+import io.newm.server.ktx.cborHexToUtxos
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ClaimOrderRequest(
+    val walletAddress: String,
+    val changeAddress: String,
+    val utxoCborHexList: List<String>,
+) {
+    val utxos: List<Utxo> by lazy { utxoCborHexList.cborHexToUtxos() }
+}

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/GetEarningsResponse.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/model/GetEarningsResponse.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GetEarningsResponse(
     val earnings: List<Earning>,
-    val totalClaimed: Long
+    val totalClaimed: Long,
+    val amountCborHex: String,
 )

--- a/newm-server/src/main/kotlin/io/newm/server/features/earnings/repo/EarningsRepository.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/earnings/repo/EarningsRepository.kt
@@ -2,6 +2,7 @@ package io.newm.server.features.earnings.repo
 
 import io.newm.server.features.earnings.model.AddSongRoyaltyRequest
 import io.newm.server.features.earnings.model.ClaimOrder
+import io.newm.server.features.earnings.model.ClaimOrderRequest
 import io.newm.server.features.earnings.model.Earning
 import io.newm.server.typealiases.SongId
 import java.util.UUID
@@ -33,7 +34,7 @@ interface EarningsRepository {
     /**
      * Create a new claim order for a stake address
      */
-    suspend fun createClaimOrder(stakeAddress: String): ClaimOrder?
+    suspend fun createClaimOrder(claimOrderRequest: ClaimOrderRequest): ClaimOrder?
 
     /**
      * Update a claim order

--- a/newm-server/src/main/resources/openapi/documentation.yaml
+++ b/newm-server/src/main/resources/openapi/documentation.yaml
@@ -597,16 +597,17 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/Earning"
+  /v1/earnings:
     post:
       tags:
         - "Earnings"
       description: "create a claim for all earnings on this wallet stake address"
-      parameters:
-        - name: "walletAddress"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimOrderRequest"
+        required: true
       responses:
         "200":
           description: "OK"
@@ -2311,6 +2312,21 @@ components:
         - "stakeAddress"
         - "memo"
         - "createdAt"
+    ClaimOrderRequest:
+      type: "object"
+      properties:
+        walletAddress:
+          type: "string"
+        changeAddress:
+          type: "string"
+        utxoCborHexList:
+          type: "array"
+          items:
+              type: "string"
+      required:
+        - "walletAddress"
+        - "changeAddress"
+        - "utxoCborHexList"
     ClaimOrder:
       type: "object"
       properties:
@@ -2353,6 +2369,8 @@ components:
           format: "date-time"
         errorMessage:
           type: "string"
+        cborHex:
+          type: "string"
       required:
         - "stakeAddress"
         - "keyId"
@@ -2360,6 +2378,7 @@ components:
         - "status"
         - "earningsIds"
         - "createdAt"
+        - "cborHex"
     BigInteger:
       type: "integer"
     AddSongRoyaltyRequest:

--- a/newm-server/src/test/kotlin/io/newm/server/features/earnings/EarningsRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/earnings/EarningsRoutesTests.kt
@@ -148,7 +148,8 @@ class EarningsRoutesTests : BaseApplicationTests() {
                     Earning(id = earning1, amount = 200, stakeAddress = testStakeAddress1, memo = "default", createdAt = createdAt),
                     Earning(id = earning2, amount = 300, stakeAddress = testStakeAddress1, memo = "default", createdAt = createdAt),
                     Earning(id = earning3, amount = 500, stakeAddress = testStakeAddress1, memo = "default", createdAt = createdAt),
-                )
+                ),
+                amountCborHex = "1a002dc6c0" // 2 ada for minutxo + 1 ada change
             )
 
             // Get it

--- a/newm-tx-builder/src/main/kotlin/io/newm/txbuilder/TransactionBuilder.kt
+++ b/newm-tx-builder/src/main/kotlin/io/newm/txbuilder/TransactionBuilder.kt
@@ -362,7 +362,7 @@ class TransactionBuilder(
     private fun createScriptDataHash() {
         if (scriptDataHash == null && (!redeemers.isNullOrEmpty() || !datums.isNullOrEmpty())) {
             // calculate the scriptDataHash - // redeemerBytes + datumBytes + languageViewMap
-            val redeemerBytes = createRedeemerWitnesses()?.toCborByteArray() ?: ByteArray(1) { 0x80.toByte() }
+            val redeemerBytes = createRedeemerWitnesses()?.toCborByteArray() ?: ByteArray(1) { 0xa0.toByte() }
             val datumBytes = createDatumWitnesses()?.toCborByteArray() ?: ByteArray(0)
             val languageViewMap =
                 if (!redeemers.isNullOrEmpty()) {


### PR DESCRIPTION
Please check the updated documentation once this is deployed. Both the GET and POST requests/responses for earnings have changed. 

The GET request includes an amountCborHex field that can be used to query the user's wallet for valid utxos to send in the POST request. The POST request requires the wallet being claimed for, a changeAddress, and the utxo list.

The response to the POST request now includes the cborHex of the transaction to sign to kick off the claiming process. Once this payment arrives, the user will be sent their tokens. 

As long as the claim order has not timed out, it's perfectly fine to call both GET and POST again if the user has closed their wallet, or declined to sign the transaction the first time. A new transaction will be built for them each time they call POST.