### PR TITLE
Ensure proper threads for InterProcessMutex

### DIFF
--- a/newm-chain-db/src/main/kotlin/io/newm/chain/util/DbKtx.kt
+++ b/newm-chain-db/src/main/kotlin/io/newm/chain/util/DbKtx.kt
@@ -25,6 +25,7 @@ import io.newm.kogmios.protocols.model.MetadataMap
 import io.newm.kogmios.protocols.model.MetadataString
 import io.newm.kogmios.protocols.model.MetadataValue
 import io.newm.kogmios.protocols.model.ScriptPlutusV2
+import io.newm.kogmios.protocols.model.ScriptPlutusV3
 import io.newm.kogmios.protocols.model.StakeCredentialRegistrationCertificate
 import io.newm.kogmios.protocols.model.StakeDelegationCertificate
 import io.newm.kogmios.protocols.model.UtxoOutput
@@ -176,8 +177,13 @@ fun List<UtxoOutput>.toCreatedUtxoList(
         lovelace = utxoOutput.value.ada.ada.lovelace,
         datumHash = datumHash,
         datum = datum,
-        // we only care about plutus v2
-        scriptRef = (utxoOutput.script as? ScriptPlutusV2)?.cbor,
+        scriptRef = utxoOutput.script?.let { script ->
+            when (script) {
+                is ScriptPlutusV2 -> script.cbor
+                is ScriptPlutusV3 -> script.cbor
+                else -> null
+            }
+        },
         nativeAssets =
             utxoOutput.value.assets
                 ?.map { asset ->

--- a/newm-server/src/main/kotlin/io/newm/server/ktx/InterProcessMutexExt.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/ktx/InterProcessMutexExt.kt
@@ -1,0 +1,35 @@
+package io.newm.server.ktx
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.withContext
+import org.apache.curator.framework.recipes.locks.InterProcessMutex
+
+// InterProcessMutext does not play nice with coroutines if the block() resumes on a different thread
+// This extension function ensures that the block() is executed on the same thread as the lock and
+// releases the lock after the block is executed on the same thread.
+
+@OptIn(ExperimentalCoroutinesApi::class)
+private val singleThreadContextCache = Caffeine
+    .newBuilder()
+    .build<String, CoroutineContext> { name ->
+        @OptIn(DelicateCoroutinesApi::class)
+        newSingleThreadContext(name)
+    }
+
+suspend fun <T> InterProcessMutex.withLock(
+    lockName: String,
+    block: suspend () -> T
+): T =
+    withContext(singleThreadContextCache.get(lockName)) {
+        // acquire() with throw and exit early if we couldn't acquire the lock
+        acquire()
+        try {
+            block()
+        } finally {
+            release()
+        }
+    }

--- a/newm-server/src/main/resources/openapi/documentation.yaml
+++ b/newm-server/src/main/resources/openapi/documentation.yaml
@@ -594,9 +594,7 @@ paths:
           content:
             'application/json':
               schema:
-                type: "array"
-                items:
-                  $ref: "#/components/schemas/Earning"
+                $ref: "#/components/schemas/GetEarningsResponse"
   /v1/earnings:
     post:
       tags:
@@ -2312,6 +2310,22 @@ components:
         - "stakeAddress"
         - "memo"
         - "createdAt"
+    GetEarningsResponse:
+      type: "object"
+      properties:
+        totalClaimed:
+          type: "integer"
+          format: "int64"
+        earnings:
+          type: "array"
+          items:
+              $ref: "#/components/schemas/Earning"
+        amountCborHex:
+          type: "string"
+      required:
+        - "totalClaimed"
+        - "earnings"
+        - "amountCborHex"
     ClaimOrderRequest:
       type: "object"
       properties:


### PR DESCRIPTION
The way coroutines work, it's possible to resume on a different thread after a suspend function. This creates an extension function so we can use InterProcessMutex with coroutines to ensure we resume on the same physical JVM thread. This allows us to confidently release() the interprocess mutex since it will be acquired and released on the same physical JVM thread.