### PR TITLE
fix: Add POST to CORS

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/cors/CorsInstall.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/cors/CorsInstall.kt
@@ -12,6 +12,7 @@ import io.newm.shared.ktx.getConfigSplitStrings
 fun Application.installCORS() {
     install(CORS) {
         allowMethod(HttpMethod.Put)
+        allowMethod(HttpMethod.Post)
         allowMethod(HttpMethod.Patch)
         allowMethod(HttpMethod.Delete)
         allowHeader(HttpHeaders.Authorization)

--- a/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/repo/SongRepositoryImpl.kt
@@ -372,7 +372,12 @@ internal class SongRepositoryImpl(
 
             checkRequester(songId, requesterId)
             val config = environment.getConfigChild("aws.s3.audio")
-            val file = data.toTempFile()
+            val file = try {
+                data.toTempFile()
+            } catch (e: Throwable) {
+                logger.error(e) { "Failed to create audio temp file" }
+                throw e
+            }
             try {
                 val size = file.length()
                 val minSize = config.getLong("minFileSize")


### PR DESCRIPTION
I had thought POST was allowed by default, but maybe we updated a dependency that changed this.