### PR TITLE
fix: Add POST to CORS attempt 2

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/cors/CorsInstall.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/cors/CorsInstall.kt
@@ -12,9 +12,12 @@ import io.newm.shared.ktx.getConfigSplitStrings
 fun Application.installCORS() {
     install(CORS) {
         allowMethod(HttpMethod.Put)
-        allowMethod(HttpMethod.Post)
         allowMethod(HttpMethod.Patch)
         allowMethod(HttpMethod.Delete)
+
+        // force POST to be allowed even though it is assumed to be a default
+        this.methods.add(HttpMethod.Post)
+
         allowHeader(HttpHeaders.Authorization)
         allowHeader(RecaptchaHeaders.Platform)
         allowHeader(RecaptchaHeaders.Token)


### PR DESCRIPTION
allowMethod doesn't actually add it if it's considered one of the "Default" allowed by cors. However, when we look at the browser logs, POST is not being sent as one of the allowed methods so maybe there's a bug somewhere in the CORS implementation of ktor.