### PR TITLE
fix: STUD-352 - revert send uncompressed image to Eveara

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryImpl.kt
@@ -998,7 +998,7 @@ class EvearaDistributionRepositoryImpl(
                         productFormat = "stereo",
                         coverImage =
                             CoverImage(
-                                url = release.coverArtUrl.asValidUrl().replace("c_limit,w_4000,h_4000/", ""),
+                                url = release.coverArtUrl.asValidUrl(),
                                 extension =
                                     release.coverArtUrl
                                         .asValidUrl()
@@ -1095,7 +1095,7 @@ class EvearaDistributionRepositoryImpl(
                         productFormat = "stereo",
                         coverImage =
                             CoverImage(
-                                url = release.coverArtUrl.asValidUrl().replace("c_limit,w_4000,h_4000/", ""),
+                                url = release.coverArtUrl.asValidUrl(),
                                 extension =
                                     release.coverArtUrl
                                         .asValidUrl()


### PR DESCRIPTION
If the image is larger than 4000x4000, eveara fails with an error. We were trying to fix the error of the user uploading an image that was too small (under 100kb). I think it's better to just have those users upload more complex images instead of blocking people with larger images sizes.