### PR TITLE
Fix logback.xml so that logs include the AWS server instance each line is coming from

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/Application.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/Application.kt
@@ -25,6 +25,7 @@ import io.newm.server.features.user.createUserRoutes
 import io.newm.server.features.walletconnection.createWalletConnectionRoutes
 import io.newm.server.forwarder.installForwarder
 import io.newm.server.health.installHealthCheck
+import io.newm.server.logging.initializeLogging
 import io.newm.server.logging.initializeSentry
 import io.newm.server.logging.installCallLogging
 import io.newm.server.staticcontent.createStaticContentRoutes
@@ -58,11 +59,11 @@ fun main(args: Array<String>) {
 
 @Suppress("unused")
 fun Application.module() {
+    initializeLogging()
     initializeSentry()
     installDependencyInjection()
     initializeDatabase()
     installCurator()
-
     installCallLogging()
     installContentNegotiation()
     installAuthentication()

--- a/newm-server/src/main/kotlin/io/newm/server/logging/InitializeLogging.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/logging/InitializeLogging.kt
@@ -1,0 +1,16 @@
+package io.newm.server.logging
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.log
+import org.slf4j.MDC
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
+
+fun Application.initializeLogging() {
+    val instanceId = try {
+        EC2MetadataUtils.getInstanceId()
+    } catch (e: Throwable) {
+        log.error("Failed to get instanceId from EC2MetadataUtils", e)
+        "instanceId-unknown"
+    }
+    MDC.put("instanceId", instanceId)
+}

--- a/newm-server/src/main/resources/logback.xml
+++ b/newm-server/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%X{instanceId}][%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">


### PR DESCRIPTION
Description

Our default logging system in logback.xml adds timestamps, threads, and class information about where each log line is coming from. However, we don’t know what AWS EC2 instance they are coming from.

Beanstalk combines all instance logs into one log file so it’s difficult to tell which server is printing the log. This is problematic when we’re dealing with things like Zookeeper leadership and you want to see which instance has the leadership.