### PR TITLE
fix: Unstaked stream token royalties go to NEWM Foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ stopServer.sh
 *_localhost.sh
 *_garage.sh
 *_studio.sh
+*_studio_usd.sh
+*_studio_newmies.sh
 
 .elasticbeanstalk
 


### PR DESCRIPTION
Current code fails with an exception if we don't find exactly 100m stream tokens on chain for a given song. This is usually because they are not in an address that is staked. If the tokens are not staked, any earnings should go to the NEWM foundation.