### PR TITLE
feat: Create an API for submitting any transaction from the marketplace

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/cardano/CardanoRoutes.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/cardano/CardanoRoutes.kt
@@ -17,6 +17,7 @@ import io.newm.server.features.cardano.model.QueryPriceResponse
 import io.newm.server.features.cardano.model.ScriptAddressWhitelistRequest
 import io.newm.server.features.cardano.model.SubmitTransactionRequest
 import io.newm.server.features.cardano.model.SubmitTransactionResponse
+import io.newm.server.features.cardano.model.SubmitTxRequest
 import io.newm.server.features.cardano.repo.CardanoRepository
 import io.newm.server.features.song.model.MintingStatus
 import io.newm.server.features.song.model.songFilters
@@ -118,6 +119,17 @@ fun Routing.createCardanoRoutes() {
         }
 
         authenticate(AUTH_JWT) {
+            post("submitTx") {
+                try {
+                    val request = receive<SubmitTxRequest>()
+                    val response = cardanoRepository.submitTransaction(request.cborHex.hexToByteArray().toByteString())
+                    respond(HttpStatusCode.Accepted, SubmitTransactionResponse(response.txId, response.result))
+                } catch (e: Exception) {
+                    log.error("Failed to submit transaction: ${e.message}")
+                    throw e
+                }
+            }
+
             post("submitTransaction") {
                 try {
                     val request = receive<SubmitTransactionRequest>()

--- a/newm-server/src/main/kotlin/io/newm/server/features/cardano/model/SubmitTxRequest.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/cardano/model/SubmitTxRequest.kt
@@ -1,0 +1,8 @@
+package io.newm.server.features.cardano.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SubmitTxRequest(
+    val cborHex: String
+)

--- a/newm-server/src/main/kotlin/io/newm/server/ktx/StringExt.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/ktx/StringExt.kt
@@ -149,6 +149,23 @@ fun List<String>?.cborHexToUtxos(): List<Utxo> = this?.map { it.cborHexToUtxo() 
  *         ],
  *     },
  * ]
+ *
+ * Example where NativeAssets use an array internally instead of map
+ * [
+ *     [
+ *         h'de03dc84fd819ac5fc1dba2e48fa18d1390b71dd022bed02eb26e276b92cece6',
+ *         0,
+ *     ],
+ *     [
+ *         h'002b5a4101c329c6613cd51091509a4f50b6028a8f20c1a161ecbb5dda55e80300b56dd9f4dc643fe0d10d099598c647ea4588c54699e8548a',
+ *         [
+ *             1176630_2,
+ *             {
+ *                 h'769c4c6e9bc3ba5406b9b89fb7beb6819e638ff2e2de63f008d5bcff': {h'744e45574d': 10000000000_3},
+ *             },
+ *         ],
+ *     ],
+ * ]
  */
 fun String.cborHexToUtxo(): Utxo {
     try {

--- a/newm-server/src/main/resources/openapi/documentation.yaml
+++ b/newm-server/src/main/resources/openapi/documentation.yaml
@@ -242,12 +242,30 @@ paths:
     post:
       tags:
         - "Cardano"
-      description: ""
+      description: "Submit a Transaction specifically for minting a song"
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/SubmitTransactionRequest"
+        required: true
+      responses:
+        "202":
+          description: "Accepted"
+          content:
+            'application/json':
+              schema:
+                $ref: "#/components/schemas/SubmitTransactionResponse"
+  /v1/cardano/submitTx:
+    post:
+      tags:
+        - "Cardano"
+      description: "Submit a Transaction to the cardano blockchain"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitTxRequest"
         required: true
       responses:
         "202":
@@ -2079,6 +2097,13 @@ components:
           type: "string"
       required:
         - "songId"
+        - "cborHex"
+    SubmitTxRequest:
+      type: "object"
+      properties:
+        cborHex:
+          type: "string"
+      required:
         - "cborHex"
     SubmitTransactionResponse:
       type: "object"

--- a/newm-server/src/test/kotlin/io/newm/server/utils/CborParseTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/utils/CborParseTest.kt
@@ -20,4 +20,22 @@ class CborParseTest {
         val utxo = cborHex.cborHexToUtxo()
         assertThat(utxo).isNotNull()
     }
+
+    @Test
+    fun testCborUtxoParse3() {
+        val cborHex =
+            "82825820de03dc84fd819ac5fc1dba2e48fa18d1390b71dd022bed02eb26e276b92cece600825839002b5a4101c329c6613cd51091509a4f50b6028a8f20c1a161ecbb5dda55e80300b56dd9f4dc643fe0d10d099598c647ea4588c54699e8548a821a0011f436a1581c769c4c6e9bc3ba5406b9b89fb7beb6819e638ff2e2de63f008d5bcffa145744e45574d1b00000002540be400"
+        val utxo = cborHex.cborHexToUtxo()
+        assertThat(utxo).isNotNull()
+        assertThat(utxo.hash).isEqualTo("de03dc84fd819ac5fc1dba2e48fa18d1390b71dd022bed02eb26e276b92cece6")
+        assertThat(utxo.ix).isEqualTo(0)
+        assertThat(utxo.address).isEqualTo("addr_test1qq445sgpcv5uvcfu65gfz5y6fagtvq523usvrgtpaja4mkj4aqpspdtdm86dceplurgs6zv4nrry06j93rz5dx0g2j9qe6k94e")
+        assertThat(utxo.lovelace).isEqualTo("1176630")
+        assertThat(utxo.hasDatum()).isFalse()
+        assertThat(utxo.nativeAssetsCount).isEqualTo(1)
+        val nativeAsset = utxo.nativeAssetsList[0]
+        assertThat(nativeAsset.policy).isEqualTo("769c4c6e9bc3ba5406b9b89fb7beb6819e638ff2e2de63f008d5bcff")
+        assertThat(nativeAsset.name).isEqualTo("744e45574d")
+        assertThat(nativeAsset.amount).isEqualTo("10000000000")
+    }
 }


### PR DESCRIPTION
The /submitTransaction endpoint is ONLY for use by newm-studio because it updates the song record status. I've added a new /submitTx endpoint that is useful for any of the other transactions we create for interacting with the marketplace.  It gives us a nice endpoint we can use to submit transactions to newm-chain instead of relying on wallet provider backends to not suck.