### PR TITLE
fix: STUD-419 - Ensure cover image file size after cloudinary compres…

### DIFF
--- a/newm-server/src/main/kotlin/io/newm/server/features/song/SongKoinModule.kt
+++ b/newm-server/src/main/kotlin/io/newm/server/features/song/SongKoinModule.kt
@@ -6,5 +6,5 @@ import org.koin.dsl.module
 
 val songKoinModule =
     module {
-        single<SongRepository> { SongRepositoryImpl(get(), get(), get(), get(), get(), get(), get(), get()) }
+        single<SongRepository> { SongRepositoryImpl(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     }

--- a/newm-server/src/test/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/distribution/eveara/EvearaDistributionRepositoryTest.kt
@@ -327,7 +327,7 @@ class EvearaDistributionRepositoryTest : BaseApplicationTests() {
 
             val configRepository: ConfigRepository = ConfigRepositoryImpl()
             val songRepository: SongRepository =
-                SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+                SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
             val applicationEnvironment: ApplicationEnvironment by inject()
             val collabRepository: CollaborationRepository =
                 CollaborationRepositoryImpl(applicationEnvironment, mockk())

--- a/newm-server/src/test/kotlin/io/newm/server/features/minting/repo/MintingRepositoryTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/minting/repo/MintingRepositoryTest.kt
@@ -303,7 +303,7 @@ class MintingRepositoryTest : BaseApplicationTests() {
             setupDatabase()
 
             val songRepository: SongRepository =
-                SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+                SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
             val collabRepository: CollaborationRepository = CollaborationRepositoryImpl(mockk(), mockk())
             val mintingRepository = MintingRepositoryImpl(mockk(), collabRepository, mockk(), mockk())
 
@@ -387,7 +387,7 @@ class MintingRepositoryTest : BaseApplicationTests() {
 
             val cardanoRepository = CardanoRepositoryImpl(client, mockk(), "", mockk(), mockk(), mockk())
             val songRepository: SongRepository =
-                SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+                SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
             val collabRepository: CollaborationRepository = CollaborationRepositoryImpl(mockk(), mockk())
             val mintingRepository = MintingRepositoryImpl(mockk(), collabRepository, cardanoRepository, mockk())
 

--- a/newm-server/src/test/kotlin/io/newm/server/features/song/SongRepositoryTest.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/song/SongRepositoryTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class SongRepositoryTest : BaseApplicationTests() {
     @Test
     fun `test calculateMintPaymentResponse`() {
-        val songRepository = SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+        val songRepository = SongRepositoryImpl(mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
         val response =
             songRepository.calculateMintPaymentResponse(
                 dspPriceUsd = 14990000L,

--- a/newm-server/src/test/kotlin/io/newm/server/features/song/SongRoutesTests.kt
+++ b/newm-server/src/test/kotlin/io/newm/server/features/song/SongRoutesTests.kt
@@ -78,7 +78,8 @@ class SongRoutesTests : BaseApplicationTests() {
                     get(),
                     get(),
                     get(),
-                    get()
+                    get(),
+                    get(),
                 )
             }
         }

--- a/newm-shared/src/main/kotlin/io/newm/shared/test/TestUtils.kt
+++ b/newm-shared/src/main/kotlin/io/newm/shared/test/TestUtils.kt
@@ -1,0 +1,11 @@
+package io.newm.shared.test
+
+object TestUtils {
+    fun isRunningInTest(): Boolean =
+        try {
+            Class.forName("org.junit.jupiter.api.Test")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+}


### PR DESCRIPTION
Perform a `head` request to get file size of coverImage when the user is trying to save a song. Prevent saving a song with a too-small image that will simply fail at eveara when they try to release. We should probably also do this check on the web side as well.