### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -308,11 +308,11 @@ object Dependencies {
         const val ALL = "org.quartz-scheduler:quartz:$VERSION"
     }
 
-    object SSLKickstart {
-        private const val VERSION = Versions.SSL_KICKSTART
+    object Ayza {
+        private const val VERSION = Versions.AYZA
 
-        const val PEM = "io.github.hakky54:sslcontext-kickstart-for-pem:$VERSION"
-        const val NETTY = "io.github.hakky54:sslcontext-kickstart-for-netty:$VERSION"
+        const val PEM = "io.github.hakky54:ayza-for-pem:$VERSION"
+        const val NETTY = "io.github.hakky54:ayza-for-netty:$VERSION"
     }
 
     object TestContainers {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -44,7 +44,7 @@ object Versions {
     const val SENTRY = "8.21.1"
     const val SHADOW_PLUGIN = "8.1.1"
     const val SPRING_SECURITY = "6.5.3"
-    const val SSL_KICKSTART = "9.2.1"
+    const val AYZA = "10.0.0"
     const val SWAGGER = "1.0.57"
     const val TEST_CONTAINERS = "1.21.3"
     const val TYPESAFE = "1.4.5"

--- a/newm-chain/build.gradle.kts
+++ b/newm-chain/build.gradle.kts
@@ -38,8 +38,8 @@ dependencies {
     implementation(project(":newm-shared"))
     implementation(Dependencies.Newm.KOGMIOS)
     implementation(Dependencies.Cbor.CBOR)
-    implementation(Dependencies.SSLKickstart.PEM)
-    implementation(Dependencies.SSLKickstart.NETTY)
+    implementation(Dependencies.Ayza.PEM)
+    implementation(Dependencies.Ayza.NETTY)
 
     compileOnly(Dependencies.Kotlin.REFLECTION)
     implementation(Dependencies.Kotlin.STDLIB_JDK8)


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience